### PR TITLE
Add connector framework foundation for external integrations

### DIFF
--- a/backend/integrations/__init__.py
+++ b/backend/integrations/__init__.py
@@ -1,0 +1,51 @@
+"""Integration / connector framework for external systems.
+
+This package provides a first-class connector layer so that agents can act
+on external systems (email, calendar, ATS, CRM, cloud storage, social
+platforms, ...) through a shared, typed interface instead of bespoke
+provider calls embedded directly in workflows.
+
+Scope of this initial implementation (see GitHub issue #138):
+
+* ``base.py`` defines the shared connector contract: auth, capability
+  discovery, typed action schemas, health checks and structured errors.
+* ``registry.py`` provides a process-wide registry so agents/tools can look
+  up connectors by name and discover which external systems a project
+  depends on before a run starts.
+* ``mocks.py`` ships a fully working in-memory email connector that
+  implements the contract, suitable for tests and connector development
+  sandboxes.
+
+Follow-up work (out of scope here): real OAuth-backed connectors for
+calendar/ATS/CRM/storage/social platforms, retry/fallback policy execution,
+and an operator-console UI for connector health/permission state.
+"""
+
+from .base import (
+    ActionSchema,
+    Connector,
+    ConnectorAction,
+    ConnectorCapability,
+    ConnectorError,
+    ConnectorHealth,
+    ConnectorHealthStatus,
+    ConnectorPermissionError,
+    ConnectorRateLimitError,
+    RateLimit,
+)
+from .registry import ConnectorRegistry, get_registry
+
+__all__ = [
+    "ActionSchema",
+    "Connector",
+    "ConnectorAction",
+    "ConnectorCapability",
+    "ConnectorError",
+    "ConnectorHealth",
+    "ConnectorHealthStatus",
+    "ConnectorPermissionError",
+    "ConnectorRateLimitError",
+    "ConnectorRegistry",
+    "RateLimit",
+    "get_registry",
+]

--- a/backend/integrations/base.py
+++ b/backend/integrations/base.py
@@ -1,0 +1,379 @@
+"""Shared connector contract for external system integrations.
+
+Every connector (email, calendar, ATS, CRM, cloud storage, social platform,
+...) implements the :class:`Connector` abstract base class defined here so
+that agents can discover capabilities and invoke actions through a single,
+typed interface rather than bespoke, provider-specific code paths.
+"""
+
+from __future__ import annotations
+
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Capability / action schema model
+# ---------------------------------------------------------------------------
+
+
+class ConnectorCapability(StrEnum):
+    """Coarse-grained capability categories a connector may support.
+
+    These map to the integration priorities called out in issue #138:
+    email, calendar, ATS/job boards, CRM, cloud storage, and social
+    platforms.
+    """
+
+    EMAIL = "email"
+    CALENDAR = "calendar"
+    ATS = "ats"
+    CRM = "crm"
+    STORAGE = "storage"
+    SOCIAL = "social"
+
+
+@dataclass(frozen=True)
+class ActionSchema:
+    """Typed description of a single action a connector exposes.
+
+    This is the unit agents use for tool discovery: rather than hardcoding
+    a bespoke function signature per provider, agents enumerate
+    ``Connector.list_actions()`` and get back a list of these schemas which
+    can be converted directly into LLM tool/function definitions.
+    """
+
+    name: str
+    description: str
+    capability: ConnectorCapability
+    parameters: dict[str, Any] = field(default_factory=dict)
+    required_permissions: tuple[str, ...] = field(default_factory=tuple)
+    is_write: bool = False
+
+    def to_tool_definition(self) -> dict[str, Any]:
+        """Render this schema as an OpenAI/Anthropic-style tool definition."""
+        return {
+            "name": self.name,
+            "description": self.description,
+            "input_schema": {
+                "type": "object",
+                "properties": self.parameters,
+                "required": list(self.parameters.keys()),
+            },
+        }
+
+
+@dataclass(frozen=True)
+class RateLimit:
+    """Simple fixed-window rate limit description for a connector."""
+
+    max_calls: int
+    window_seconds: float
+
+    def __post_init__(self) -> None:
+        if self.max_calls <= 0:
+            raise ValueError("max_calls must be positive")
+        if self.window_seconds <= 0:
+            raise ValueError("window_seconds must be positive")
+
+
+class ConnectorHealthStatus(StrEnum):
+    """Operational state of a connector, surfaced to operator tooling."""
+
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+    UNAUTHORIZED = "unauthorized"
+    DOWN = "down"
+    UNKNOWN = "unknown"
+
+
+@dataclass
+class ConnectorHealth:
+    """Health/permission snapshot for a connector instance."""
+
+    status: ConnectorHealthStatus
+    detail: str = ""
+    missing_permissions: tuple[str, ...] = field(default_factory=tuple)
+    checked_at: float = field(default_factory=time.time)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status.value,
+            "detail": self.detail,
+            "missing_permissions": list(self.missing_permissions),
+            "checked_at": self.checked_at,
+        }
+
+
+@dataclass
+class ConnectorAction:
+    """The result of invoking an action on a connector."""
+
+    success: bool
+    data: Any = None
+    error: ConnectorError | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "success": self.success,
+            "data": self.data,
+            "error": self.error.to_dict() if self.error else None,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Structured errors
+# ---------------------------------------------------------------------------
+
+
+class ConnectorError(Exception):
+    """Base class for actionable connector errors.
+
+    Carries enough structure (``retryable``, ``fallback_hint``) for the
+    runtime to decide whether to retry, fall back to another connector, or
+    surface the failure to the operator.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        retryable: bool = False,
+        fallback_hint: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.retryable = retryable
+        self.fallback_hint = fallback_hint
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "type": type(self).__name__,
+            "message": self.message,
+            "retryable": self.retryable,
+            "fallback_hint": self.fallback_hint,
+        }
+
+
+class ConnectorPermissionError(ConnectorError):
+    """Raised when the connector lacks permission to perform an action."""
+
+    def __init__(self, message: str, *, missing_permissions: tuple[str, ...] = ()) -> None:
+        super().__init__(
+            message,
+            retryable=False,
+            fallback_hint="Reconnect or re-authorize the connector with the required scopes.",
+        )
+        self.missing_permissions = missing_permissions
+
+    def to_dict(self) -> dict[str, Any]:
+        data = super().to_dict()
+        data["missing_permissions"] = list(self.missing_permissions)
+        return data
+
+
+class ConnectorRateLimitError(ConnectorError):
+    """Raised when a connector's rate limit has been exceeded."""
+
+    def __init__(self, message: str, *, retry_after_seconds: float) -> None:
+        super().__init__(
+            message,
+            retryable=True,
+            fallback_hint="Retry after the cooldown window or route to a fallback connector.",
+        )
+        self.retry_after_seconds = retry_after_seconds
+
+    def to_dict(self) -> dict[str, Any]:
+        data = super().to_dict()
+        data["retry_after_seconds"] = self.retry_after_seconds
+        return data
+
+
+class ConnectorAuthError(ConnectorError):
+    """Raised when authentication with the external system fails."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(
+            message,
+            retryable=False,
+            fallback_hint="Refresh credentials and retry the connection.",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Rate limiter helper (simple fixed-window counter, in-process)
+# ---------------------------------------------------------------------------
+
+
+class _FixedWindowLimiter:
+    def __init__(self, rate_limit: RateLimit | None) -> None:
+        self._rate_limit = rate_limit
+        self._window_start = time.time()
+        self._calls_in_window = 0
+
+    def check(self) -> None:
+        if self._rate_limit is None:
+            return
+        now = time.time()
+        elapsed = now - self._window_start
+        if elapsed >= self._rate_limit.window_seconds:
+            self._window_start = now
+            self._calls_in_window = 0
+        if self._calls_in_window >= self._rate_limit.max_calls:
+            retry_after = self._rate_limit.window_seconds - elapsed
+            raise ConnectorRateLimitError(
+                f"Rate limit of {self._rate_limit.max_calls} calls per "
+                f"{self._rate_limit.window_seconds}s exceeded.",
+                retry_after_seconds=max(retry_after, 0.0),
+            )
+        self._calls_in_window += 1
+
+
+# ---------------------------------------------------------------------------
+# Connector base class
+# ---------------------------------------------------------------------------
+
+
+class Connector(ABC):
+    """Shared interface every connector implementation must satisfy.
+
+    Subclasses provide:
+      * ``name`` / ``capabilities`` describing what the connector is and does.
+      * ``authenticate()`` to establish/validate credentials.
+      * ``list_actions()`` for capability discovery (typed tool definitions).
+      * ``execute(action_name, **kwargs)`` to perform a read/write action.
+      * ``health_check()`` to report operational + permission state.
+    """
+
+    #: Human-readable connector name, e.g. "gmail", "google_calendar".
+    name: str = "connector"
+
+    #: Capabilities this connector exposes (email, calendar, crm, ...).
+    capabilities: tuple[ConnectorCapability, ...] = ()
+
+    #: Optional rate limit applied to every ``execute`` call.
+    rate_limit: RateLimit | None = None
+
+    def __init__(self) -> None:
+        self._authenticated = False
+        self._granted_permissions: set[str] = set()
+        self._limiter = _FixedWindowLimiter(self.rate_limit)
+
+    # -- auth -----------------------------------------------------------
+
+    @abstractmethod
+    def authenticate(self, credentials: dict[str, Any]) -> None:
+        """Validate and store credentials for this connector instance.
+
+        Implementations should set ``self._authenticated`` and populate
+        ``self._granted_permissions`` based on the scopes present in
+        *credentials*.
+        """
+
+    @property
+    def is_authenticated(self) -> bool:
+        return self._authenticated
+
+    @property
+    def granted_permissions(self) -> frozenset[str]:
+        return frozenset(self._granted_permissions)
+
+    # -- capability discovery --------------------------------------------
+
+    @abstractmethod
+    def list_actions(self) -> list[ActionSchema]:
+        """Return the typed action schemas this connector supports."""
+
+    def get_tool_definitions(self) -> list[dict[str, Any]]:
+        """Convenience wrapper: actions rendered as LLM tool definitions."""
+        return [action.to_tool_definition() for action in self.list_actions()]
+
+    def _find_action(self, action_name: str) -> ActionSchema:
+        for action in self.list_actions():
+            if action.name == action_name:
+                return action
+        raise ConnectorError(
+            f"Unknown action '{action_name}' for connector '{self.name}'.",
+            retryable=False,
+            fallback_hint="Call list_actions() to discover supported actions.",
+        )
+
+    # -- execution --------------------------------------------------------
+
+    def execute(self, action_name: str, **kwargs: Any) -> ConnectorAction:
+        """Validate, rate-limit, and dispatch *action_name* with *kwargs*.
+
+        Wraps :meth:`_execute_action` so that every connector gets
+        permission checks, rate limiting, and structured error handling for
+        free.
+        """
+        try:
+            action = self._find_action(action_name)
+        except ConnectorError as exc:
+            return ConnectorAction(success=False, error=exc)
+
+        if not self.is_authenticated:
+            auth_error = ConnectorAuthError(
+                f"Connector '{self.name}' is not authenticated."
+            )
+            return ConnectorAction(success=False, error=auth_error)
+
+        missing = [
+            perm for perm in action.required_permissions
+            if perm not in self._granted_permissions
+        ]
+        if missing:
+            permission_error = ConnectorPermissionError(
+                f"Connector '{self.name}' is missing permissions for "
+                f"action '{action_name}': {', '.join(missing)}.",
+                missing_permissions=tuple(missing),
+            )
+            return ConnectorAction(success=False, error=permission_error)
+
+        try:
+            self._limiter.check()
+        except ConnectorRateLimitError as exc:
+            return ConnectorAction(success=False, error=exc)
+
+        try:
+            result = self._execute_action(action_name, **kwargs)
+            return ConnectorAction(success=True, data=result)
+        except ConnectorError as exc:
+            return ConnectorAction(success=False, error=exc)
+        except Exception as exc:  # pragma: no cover - defensive catch-all
+            wrapped = ConnectorError(
+                f"Unexpected error executing '{action_name}' on "
+                f"'{self.name}': {exc}",
+                retryable=True,
+                fallback_hint="Retry once; escalate to operator if it recurs.",
+            )
+            return ConnectorAction(success=False, error=wrapped)
+
+    @abstractmethod
+    def _execute_action(self, action_name: str, **kwargs: Any) -> Any:
+        """Subclass hook implementing the actual side effect for an action."""
+
+    # -- health -------------------------------------------------------------
+
+    def health_check(self) -> ConnectorHealth:
+        """Default health check; subclasses may override for richer checks."""
+        if not self.is_authenticated:
+            return ConnectorHealth(
+                status=ConnectorHealthStatus.UNAUTHORIZED,
+                detail=f"Connector '{self.name}' has not authenticated.",
+            )
+        required = {
+            perm
+            for action in self.list_actions()
+            for perm in action.required_permissions
+        }
+        missing = tuple(sorted(required - self._granted_permissions))
+        if missing:
+            return ConnectorHealth(
+                status=ConnectorHealthStatus.DEGRADED,
+                detail="Some actions are unavailable due to missing permissions.",
+                missing_permissions=missing,
+            )
+        return ConnectorHealth(status=ConnectorHealthStatus.HEALTHY, detail="OK")

--- a/backend/integrations/mocks.py
+++ b/backend/integrations/mocks.py
@@ -1,0 +1,163 @@
+"""In-memory mock connectors for connector development and testing.
+
+These connectors implement the full :class:`~integrations.base.Connector`
+contract against in-memory state instead of a real third-party API. They
+let connector development, agent tool wiring, and unit tests proceed
+without live credentials, per the "testable mocks/sandboxes for connector
+development" requirement in issue #138.
+"""
+
+from __future__ import annotations
+
+import itertools
+from dataclasses import dataclass
+from typing import Any
+
+from .base import (
+    ActionSchema,
+    Connector,
+    ConnectorCapability,
+    ConnectorError,
+    ConnectorHealth,
+    ConnectorHealthStatus,
+    RateLimit,
+)
+
+_PERMISSION_SEND = "email.send"
+_PERMISSION_READ = "email.read"
+
+
+@dataclass
+class _MockMessage:
+    id: int
+    to: str
+    subject: str
+    body: str
+    sender: str = "me@example.com"
+
+
+class MockEmailConnector(Connector):
+    """A fully functional in-memory email connector sandbox.
+
+    Supports sending mail (write) and listing/searching the inbox (read),
+    gated by the ``email.send`` / ``email.read`` permissions respectively,
+    so permission-denial and partial-capability paths can be exercised in
+    tests without any network access.
+    """
+
+    name = "mock_email"
+    capabilities = (ConnectorCapability.EMAIL,)
+    rate_limit = RateLimit(max_calls=20, window_seconds=60.0)
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._sent: list[_MockMessage] = []
+        self._id_counter = itertools.count(1)
+        self._simulated_down = False
+
+    # -- auth -------------------------------------------------------------
+
+    def authenticate(self, credentials: dict[str, Any]) -> None:
+        token = credentials.get("token")
+        if not token:
+            raise ConnectorError(
+                "Missing 'token' in credentials for mock_email connector.",
+                retryable=False,
+                fallback_hint="Provide a non-empty token to authenticate.",
+            )
+        scopes = credentials.get("scopes", [_PERMISSION_SEND, _PERMISSION_READ])
+        self._granted_permissions = set(scopes)
+        self._authenticated = True
+
+    # -- capability discovery ---------------------------------------------
+
+    def list_actions(self) -> list[ActionSchema]:
+        return [
+            ActionSchema(
+                name="send_email",
+                description="Send an email to a recipient.",
+                capability=ConnectorCapability.EMAIL,
+                parameters={
+                    "to": {"type": "string", "description": "Recipient address."},
+                    "subject": {"type": "string", "description": "Email subject."},
+                    "body": {"type": "string", "description": "Email body text."},
+                },
+                required_permissions=(_PERMISSION_SEND,),
+                is_write=True,
+            ),
+            ActionSchema(
+                name="list_sent",
+                description="List previously sent emails.",
+                capability=ConnectorCapability.EMAIL,
+                parameters={},
+                required_permissions=(_PERMISSION_READ,),
+                is_write=False,
+            ),
+            ActionSchema(
+                name="search_sent",
+                description="Search sent emails by subject substring.",
+                capability=ConnectorCapability.EMAIL,
+                parameters={
+                    "query": {"type": "string", "description": "Subject substring to match."},
+                },
+                required_permissions=(_PERMISSION_READ,),
+                is_write=False,
+            ),
+        ]
+
+    # -- execution ----------------------------------------------------------
+
+    def _execute_action(self, action_name: str, **kwargs: Any) -> Any:
+        if self._simulated_down:
+            raise ConnectorError(
+                "mock_email connector is simulated as down.",
+                retryable=True,
+                fallback_hint="Wait for the connector to recover or use a fallback connector.",
+            )
+
+        if action_name == "send_email":
+            return self._send_email(**kwargs)
+        if action_name == "list_sent":
+            return self._list_sent()
+        if action_name == "search_sent":
+            return self._search_sent(**kwargs)
+        raise ConnectorError(f"Action '{action_name}' is not implemented.")
+
+    def _send_email(self, to: str, subject: str, body: str) -> dict[str, Any]:
+        if not to or "@" not in to:
+            raise ConnectorError(
+                f"Invalid recipient address: {to!r}",
+                retryable=False,
+                fallback_hint="Provide a valid email address for 'to'.",
+            )
+        message = _MockMessage(id=next(self._id_counter), to=to, subject=subject, body=body)
+        self._sent.append(message)
+        return {"id": message.id, "to": message.to, "subject": message.subject}
+
+    def _list_sent(self) -> list[dict[str, Any]]:
+        return [
+            {"id": m.id, "to": m.to, "subject": m.subject, "body": m.body}
+            for m in self._sent
+        ]
+
+    def _search_sent(self, query: str) -> list[dict[str, Any]]:
+        query_lower = query.lower()
+        return [
+            {"id": m.id, "to": m.to, "subject": m.subject, "body": m.body}
+            for m in self._sent
+            if query_lower in m.subject.lower()
+        ]
+
+    # -- test/sandbox helpers ------------------------------------------------
+
+    def simulate_outage(self, down: bool = True) -> None:
+        """Toggle a simulated outage to exercise health/retry/fallback paths."""
+        self._simulated_down = down
+
+    def health_check(self) -> ConnectorHealth:
+        if self._simulated_down:
+            return ConnectorHealth(
+                status=ConnectorHealthStatus.DOWN,
+                detail="mock_email connector is simulated as down.",
+            )
+        return super().health_check()

--- a/backend/integrations/registry.py
+++ b/backend/integrations/registry.py
@@ -1,0 +1,99 @@
+"""Process-wide registry for connector instances.
+
+The registry lets agents look up connectors by name (typed tool selection
+instead of bespoke code paths) and lets the runtime/operator console ask
+"which external systems does this project depend on, and are they
+healthy?" before a run starts.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .base import Connector, ConnectorCapability, ConnectorHealth
+
+
+class ConnectorRegistry:
+    """In-memory registry mapping connector names to instances."""
+
+    def __init__(self) -> None:
+        self._connectors: dict[str, Connector] = {}
+
+    def register(self, connector: Connector) -> None:
+        """Register *connector*, keyed by its ``name`` attribute."""
+        if not connector.name:
+            raise ValueError("Connector must have a non-empty 'name'.")
+        self._connectors[connector.name] = connector
+
+    def unregister(self, name: str) -> None:
+        self._connectors.pop(name, None)
+
+    def get(self, name: str) -> Connector | None:
+        return self._connectors.get(name)
+
+    def require(self, name: str) -> Connector:
+        connector = self.get(name)
+        if connector is None:
+            raise KeyError(f"No connector registered under name '{name}'.")
+        return connector
+
+    def list_connectors(self) -> list[Connector]:
+        return list(self._connectors.values())
+
+    def find_by_capability(self, capability: ConnectorCapability) -> list[Connector]:
+        """Return all registered connectors that support *capability*.
+
+        This is how agents discover a connector for a task ("I need an
+        email connector") without hardcoding a specific provider.
+        """
+        return [
+            connector
+            for connector in self._connectors.values()
+            if capability in connector.capabilities
+        ]
+
+    def get_tool_definitions(self) -> list[dict[str, Any]]:
+        """Aggregate tool definitions across every registered connector.
+
+        Each tool definition is namespaced with the connector name so
+        agents can disambiguate identical action names across providers
+        (e.g. ``gmail.send_email`` vs ``outlook.send_email``).
+        """
+        definitions: list[dict[str, Any]] = []
+        for connector in self._connectors.values():
+            for tool in connector.get_tool_definitions():
+                namespaced = dict(tool)
+                namespaced["name"] = f"{connector.name}.{tool['name']}"
+                definitions.append(namespaced)
+        return definitions
+
+    def describe_dependencies(self) -> list[dict[str, Any]]:
+        """Report which external systems are registered and their health.
+
+        Intended to back a "pre-run dependency check": before an agent run
+        starts, the runtime can call this to surface unhealthy or
+        unauthorized connectors to the operator.
+        """
+        report: list[dict[str, Any]] = []
+        for connector in self._connectors.values():
+            health: ConnectorHealth = connector.health_check()
+            report.append(
+                {
+                    "name": connector.name,
+                    "capabilities": [c.value for c in connector.capabilities],
+                    "health": health.to_dict(),
+                }
+            )
+        return report
+
+    def clear(self) -> None:
+        """Remove all registered connectors. Primarily for test isolation."""
+        self._connectors.clear()
+
+
+_default_registry = ConnectorRegistry()
+
+
+def get_registry() -> ConnectorRegistry:
+    """Return the process-wide default :class:`ConnectorRegistry`."""
+    return _default_registry

--- a/backend/tests/test_integrations.py
+++ b/backend/tests/test_integrations.py
@@ -1,0 +1,307 @@
+"""Tests for the connector/integration framework (see GitHub issue #138)."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from integrations.base import (
+    ActionSchema,
+    Connector,
+    ConnectorAuthError,
+    ConnectorCapability,
+    ConnectorError,
+    ConnectorHealthStatus,
+    ConnectorPermissionError,
+    ConnectorRateLimitError,
+    RateLimit,
+)
+from integrations.mocks import MockEmailConnector
+from integrations.registry import ConnectorRegistry, get_registry
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def connector() -> MockEmailConnector:
+    c = MockEmailConnector()
+    c.authenticate({"token": "abc123"})
+    return c
+
+
+@pytest.fixture()
+def registry() -> ConnectorRegistry:
+    return ConnectorRegistry()
+
+
+# ---------------------------------------------------------------------------
+# Capability discovery / typed tool definitions
+# ---------------------------------------------------------------------------
+
+
+def test_list_actions_returns_typed_schemas(connector: MockEmailConnector) -> None:
+    actions = connector.list_actions()
+    names = {a.name for a in actions}
+    assert names == {"send_email", "list_sent", "search_sent"}
+    assert all(isinstance(a, ActionSchema) for a in actions)
+    send = next(a for a in actions if a.name == "send_email")
+    assert send.capability == ConnectorCapability.EMAIL
+    assert send.is_write is True
+    assert "email.send" in send.required_permissions
+
+
+def test_get_tool_definitions_renders_llm_tool_shape(connector: MockEmailConnector) -> None:
+    tools = connector.get_tool_definitions()
+    send_tool = next(t for t in tools if t["name"] == "send_email")
+    assert send_tool["input_schema"]["type"] == "object"
+    assert set(send_tool["input_schema"]["required"]) == {"to", "subject", "body"}
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+def test_unauthenticated_connector_rejects_execute() -> None:
+    c = MockEmailConnector()
+    result = c.execute("send_email", to="a@example.com", subject="hi", body="hello")
+    assert result.success is False
+    assert isinstance(result.error, ConnectorAuthError)
+
+
+def test_authenticate_requires_token() -> None:
+    c = MockEmailConnector()
+    with pytest.raises(ConnectorError):
+        c.authenticate({})
+
+
+def test_authenticate_grants_default_scopes() -> None:
+    c = MockEmailConnector()
+    c.authenticate({"token": "tok"})
+    assert c.is_authenticated
+    assert "email.send" in c.granted_permissions
+    assert "email.read" in c.granted_permissions
+
+
+# ---------------------------------------------------------------------------
+# Execution: success paths
+# ---------------------------------------------------------------------------
+
+
+def test_send_email_success(connector: MockEmailConnector) -> None:
+    result = connector.execute(
+        "send_email", to="alice@example.com", subject="Hello", body="Hi Alice"
+    )
+    assert result.success is True
+    assert result.data["to"] == "alice@example.com"
+    assert result.data["subject"] == "Hello"
+
+
+def test_list_sent_after_send(connector: MockEmailConnector) -> None:
+    connector.execute("send_email", to="bob@example.com", subject="Re: project", body="...")
+    result = connector.execute("list_sent")
+    assert result.success is True
+    assert len(result.data) == 1
+    assert result.data[0]["to"] == "bob@example.com"
+
+
+def test_search_sent_matches_subject(connector: MockEmailConnector) -> None:
+    connector.execute("send_email", to="a@example.com", subject="Invoice #1", body="x")
+    connector.execute("send_email", to="b@example.com", subject="Meeting notes", body="y")
+    result = connector.execute("search_sent", query="invoice")
+    assert result.success is True
+    assert len(result.data) == 1
+    assert result.data[0]["subject"] == "Invoice #1"
+
+
+# ---------------------------------------------------------------------------
+# Execution: failure paths (actionable errors)
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_action_returns_connector_error(connector: MockEmailConnector) -> None:
+    result = connector.execute("delete_everything")
+    assert result.success is False
+    assert isinstance(result.error, ConnectorError)
+    assert "Unknown action" in result.error.message
+
+
+def test_invalid_recipient_returns_actionable_error(connector: MockEmailConnector) -> None:
+    result = connector.execute("send_email", to="not-an-email", subject="x", body="y")
+    assert result.success is False
+    assert result.error.retryable is False
+    assert result.error.fallback_hint is not None
+
+
+def test_missing_permission_blocks_action() -> None:
+    c = MockEmailConnector()
+    c.authenticate({"token": "tok", "scopes": ["email.read"]})
+    result = c.execute("send_email", to="a@example.com", subject="x", body="y")
+    assert result.success is False
+    assert isinstance(result.error, ConnectorPermissionError)
+    assert "email.send" in result.error.missing_permissions
+
+
+def test_simulated_outage_is_retryable(connector: MockEmailConnector) -> None:
+    connector.simulate_outage(True)
+    result = connector.execute("list_sent")
+    assert result.success is False
+    assert result.error.retryable is True
+    health = connector.health_check()
+    assert health.status == ConnectorHealthStatus.DOWN
+
+
+def test_outage_recovers_after_toggle(connector: MockEmailConnector) -> None:
+    connector.simulate_outage(True)
+    connector.simulate_outage(False)
+    result = connector.execute("list_sent")
+    assert result.success is True
+
+
+# ---------------------------------------------------------------------------
+# Rate limiting
+# ---------------------------------------------------------------------------
+
+
+def test_rate_limit_blocks_after_threshold() -> None:
+    c = MockEmailConnector()
+    c.rate_limit = RateLimit(max_calls=2, window_seconds=60.0)
+    c._limiter = type(c._limiter)(c.rate_limit)
+    c.authenticate({"token": "tok"})
+
+    assert c.execute("list_sent").success is True
+    assert c.execute("list_sent").success is True
+    third = c.execute("list_sent")
+    assert third.success is False
+    assert isinstance(third.error, ConnectorRateLimitError)
+    assert third.error.retryable is True
+
+
+def test_rate_limit_window_resets(monkeypatch: pytest.MonkeyPatch) -> None:
+    c = MockEmailConnector()
+    c.rate_limit = RateLimit(max_calls=1, window_seconds=0.05)
+    c._limiter = type(c._limiter)(c.rate_limit)
+    c.authenticate({"token": "tok"})
+
+    assert c.execute("list_sent").success is True
+    assert c.execute("list_sent").success is False
+    time.sleep(0.06)
+    assert c.execute("list_sent").success is True
+
+
+# ---------------------------------------------------------------------------
+# Health checks
+# ---------------------------------------------------------------------------
+
+
+def test_health_check_healthy_when_fully_authorized(connector: MockEmailConnector) -> None:
+    health = connector.health_check()
+    assert health.status == ConnectorHealthStatus.HEALTHY
+
+
+def test_health_check_degraded_with_partial_permissions() -> None:
+    c = MockEmailConnector()
+    c.authenticate({"token": "tok", "scopes": ["email.read"]})
+    health = c.health_check()
+    assert health.status == ConnectorHealthStatus.DEGRADED
+    assert "email.send" in health.missing_permissions
+
+
+def test_health_check_unauthorized_before_auth() -> None:
+    c = MockEmailConnector()
+    health = c.health_check()
+    assert health.status == ConnectorHealthStatus.UNAUTHORIZED
+
+
+# ---------------------------------------------------------------------------
+# Registry: discovery and dependency reporting
+# ---------------------------------------------------------------------------
+
+
+def test_registry_register_and_get(registry: ConnectorRegistry, connector: MockEmailConnector) -> None:
+    registry.register(connector)
+    assert registry.get("mock_email") is connector
+    assert registry.get("nonexistent") is None
+
+
+def test_registry_require_raises_for_missing(registry: ConnectorRegistry) -> None:
+    with pytest.raises(KeyError):
+        registry.require("nope")
+
+
+def test_registry_find_by_capability(registry: ConnectorRegistry, connector: MockEmailConnector) -> None:
+    registry.register(connector)
+    found = registry.find_by_capability(ConnectorCapability.EMAIL)
+    assert connector in found
+    assert registry.find_by_capability(ConnectorCapability.CRM) == []
+
+
+def test_registry_namespaced_tool_definitions(registry: ConnectorRegistry, connector: MockEmailConnector) -> None:
+    registry.register(connector)
+    tools = registry.get_tool_definitions()
+    names = {t["name"] for t in tools}
+    assert "mock_email.send_email" in names
+
+
+def test_registry_describe_dependencies_reports_health(
+    registry: ConnectorRegistry, connector: MockEmailConnector
+) -> None:
+    registry.register(connector)
+    report = registry.describe_dependencies()
+    assert len(report) == 1
+    assert report[0]["name"] == "mock_email"
+    assert report[0]["capabilities"] == ["email"]
+    assert report[0]["health"]["status"] == "healthy"
+
+
+def test_registry_describe_dependencies_surfaces_unhealthy_connector(
+    registry: ConnectorRegistry, connector: MockEmailConnector
+) -> None:
+    connector.simulate_outage(True)
+    registry.register(connector)
+    report = registry.describe_dependencies()
+    assert report[0]["health"]["status"] == "down"
+
+
+def test_default_registry_singleton_is_shared() -> None:
+    a = get_registry()
+    b = get_registry()
+    assert a is b
+
+
+# ---------------------------------------------------------------------------
+# Custom connector smoke test (verifies the abstract contract is reusable)
+# ---------------------------------------------------------------------------
+
+
+class _EchoConnector(Connector):
+    name = "echo"
+    capabilities = (ConnectorCapability.CRM,)
+
+    def authenticate(self, credentials: dict) -> None:
+        self._authenticated = True
+        self._granted_permissions = {"crm.read"}
+
+    def list_actions(self) -> list[ActionSchema]:
+        return [
+            ActionSchema(
+                name="echo",
+                description="Echo back the input.",
+                capability=ConnectorCapability.CRM,
+                parameters={"value": {"type": "string"}},
+                required_permissions=("crm.read",),
+            )
+        ]
+
+    def _execute_action(self, action_name: str, **kwargs):
+        return kwargs.get("value")
+
+
+def test_custom_connector_implements_shared_contract() -> None:
+    c = _EchoConnector()
+    c.authenticate({})
+    result = c.execute("echo", value="hi")
+    assert result.success is True
+    assert result.data == "hi"


### PR DESCRIPTION
Addresses #138

## What this PR implements

Issue #138 is a large epic ("Add integration framework for email, ATS, CRM, storage, and social platforms"). This PR implements the **core connector contract and discovery layer** that all future provider-specific connectors will build on:

- `backend/integrations/base.py`:
  - `Connector` abstract base class with a shared interface for `authenticate()`, `list_actions()`, and `execute()`.
  - `ActionSchema` — typed action/capability descriptions that render directly into LLM tool/function definitions (`to_tool_definition()`), so agents can choose connectors via typed tool definitions instead of bespoke code paths.
  - `ConnectorCapability` enum covering the prioritized integration categories from the issue: email, calendar, ATS, CRM, storage, social.
  - Structured, actionable errors: `ConnectorError` (base, with `retryable` / `fallback_hint`), `ConnectorPermissionError`, `ConnectorRateLimitError`, `ConnectorAuthError`.
  - Built-in permission checks and a simple fixed-window `RateLimit` enforced automatically inside `execute()`.
  - `ConnectorHealth` / `ConnectorHealthStatus` for reporting operational + permission state (healthy / degraded / unauthorized / down).
- `backend/integrations/registry.py`:
  - `ConnectorRegistry` for registering connectors and looking them up by name or by `ConnectorCapability`.
  - `get_tool_definitions()` aggregates namespaced tool definitions (`<connector>.<action>`) across all registered connectors for agent consumption.
  - `describe_dependencies()` reports each registered connector's capabilities and health — the building block for "report which external systems a project depends on before a run starts."
  - Process-wide default registry via `get_registry()`.
- `backend/integrations/mocks.py`:
  - `MockEmailConnector` — a fully working in-memory email connector (send/list/search) implementing the complete contract, including permission-gated actions, a simulated outage mode for exercising retry/fallback/health paths, and validation errors. This is the "testable mock/sandbox for connector development" called out in the issue.
- `backend/tests/test_integrations.py`: 26 tests covering capability discovery, tool-definition rendering, auth, permission enforcement, rate limiting (including window reset), simulated outages/health, registry lookup/discovery, and dependency reporting. All pass; `ruff check` and `mypy` are clean on the new code.

## Out of scope / left for follow-up

- Real OAuth-backed connectors for any concrete provider (Gmail, Outlook, Google Calendar, ATS/job boards such as Greenhouse/Lever, CRMs such as Salesforce/HubSpot, cloud storage such as Google Drive/S3, social platforms such as LinkedIn/Twitter).
- Wiring the registry into the agent runtime so agents actually select/call connectors as tools during a run.
- Persisted connector configuration/credential storage (current auth is in-memory, per-instance).
- Retry/backoff policy *execution* (the error model carries `retryable`/`fallback_hint` hints, but no retry loop or fallback-routing logic is implemented yet).
- Operator console UI for connector health/permission state (the data is exposed via `ConnectorRegistry.describe_dependencies()`, but there's no frontend surface for it yet).
- Pre-run dependency gating in the actual run pipeline (the API to ask "what does this project depend on" exists; nothing calls it before a run starts yet).

## Test plan

- [x] `pytest backend/tests/test_integrations.py -v` — 26/26 passing
- [x] `ruff check backend/integrations/ backend/tests/test_integrations.py` — clean
- [x] `mypy backend/integrations/ --ignore-missing-imports` — clean
- [x] Confirmed no regressions in adjacent already-passing backend test files


---
_Generated by [Claude Code](https://claude.ai/code/session_01XDp718wense5Kj6ZS2x68P)_