### PR TITLE
Add mobile monitoring and intervention UI for autonomous runs

### DIFF
--- a/packages/mobile/app/approvals.tsx
+++ b/packages/mobile/app/approvals.tsx
@@ -1,0 +1,309 @@
+import React, { useState, useEffect, useCallback } from "react";
+import {
+  View, Text, FlatList, TouchableOpacity, StyleSheet,
+  SafeAreaView, RefreshControl, ActivityIndicator, Alert, TextInput, Modal,
+} from "react-native";
+import { router } from "expo-router";
+import { useAppTheme, useAppAuth } from "./_layout";
+import { BottomNav } from "../src/components/BottomNav";
+import { getPendingApprovals, approveRun, rejectRun, ApprovalRequest } from "../src/api";
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+function formatWorkflow(name: string): string {
+  return name.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export default function ApprovalsScreen() {
+  const { theme } = useAppTheme();
+  const { token } = useAppAuth();
+  const [approvals, setApprovals] = useState<ApprovalRequest[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [acting, setActing] = useState<string | null>(null);
+
+  // Reject modal state
+  const [rejectTarget, setRejectTarget] = useState<ApprovalRequest | null>(null);
+  const [rejectReason, setRejectReason] = useState("");
+
+  const fetchApprovals = useCallback(async () => {
+    try {
+      setError(null);
+      setApprovals(await getPendingApprovals());
+    } catch {
+      setError("Could not load approvals.");
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!token) { router.replace("/login"); return; }
+    fetchApprovals().finally(() => setLoading(false));
+  }, [token, fetchApprovals]);
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await fetchApprovals();
+    setRefreshing(false);
+  }, [fetchApprovals]);
+
+  const handleApprove = async (item: ApprovalRequest) => {
+    Alert.alert(
+      "Approve run",
+      `Approve "${formatWorkflow(item.workflow)}"?\n\n${item.message}`,
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Approve",
+          onPress: async () => {
+            setActing(item.id);
+            try {
+              await approveRun(item.run_id, item.id);
+              setApprovals((prev) => prev.filter((a) => a.id !== item.id));
+            } catch {
+              Alert.alert("Error", "Could not approve. Please try again.");
+            } finally {
+              setActing(null);
+            }
+          },
+        },
+      ]
+    );
+  };
+
+  const handleRejectConfirm = async () => {
+    if (!rejectTarget) return;
+    if (!rejectReason.trim()) {
+      Alert.alert("Reason required", "Please enter a reason for rejection.");
+      return;
+    }
+    const target = rejectTarget;
+    setRejectTarget(null);
+    setActing(target.id);
+    try {
+      await rejectRun(target.run_id, target.id, rejectReason.trim());
+      setApprovals((prev) => prev.filter((a) => a.id !== target.id));
+    } catch {
+      Alert.alert("Error", "Could not reject. Please try again.");
+    } finally {
+      setActing(null);
+      setRejectReason("");
+    }
+  };
+
+  const renderItem = ({ item }: { item: ApprovalRequest }) => {
+    const isActing = acting === item.id;
+    return (
+      <View style={[styles.card, { backgroundColor: theme.surface, borderColor: "#8B5CF6" }]}>
+        {/* Tap card header to go to full run detail */}
+        <TouchableOpacity
+          onPress={() => router.push({ pathname: "/run/[id]", params: { id: item.run_id } })}
+          accessibilityRole="button"
+          accessibilityLabel={`View ${formatWorkflow(item.workflow)} run detail`}
+        >
+          <View style={styles.cardHeader}>
+            <View style={styles.cardLeft}>
+              <Text style={[styles.workflow, { color: theme.text }]} numberOfLines={1}>
+                {formatWorkflow(item.workflow)}
+              </Text>
+              <Text style={[styles.time, { color: theme.textMuted }]}>
+                Requested {relativeTime(item.created_at)}
+              </Text>
+            </View>
+            <Text style={[styles.arrow, { color: theme.textMuted }]}>›</Text>
+          </View>
+          <Text style={[styles.message, { color: theme.text }]} numberOfLines={3}>
+            {item.message}
+          </Text>
+          {item.context ? (
+            <Text style={[styles.context, { color: theme.textMuted }]} numberOfLines={2}>
+              {item.context}
+            </Text>
+          ) : null}
+        </TouchableOpacity>
+
+        {/* Action buttons */}
+        <View style={styles.actions}>
+          <TouchableOpacity
+            style={[styles.btn, styles.rejectBtn, { borderColor: "#EF4444" }]}
+            onPress={() => { setRejectTarget(item); setRejectReason(""); }}
+            disabled={isActing}
+            accessibilityRole="button"
+            accessibilityLabel={`Reject ${formatWorkflow(item.workflow)}`}
+          >
+            <Text style={[styles.btnText, { color: "#EF4444" }]}>✗  Reject</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.btn, styles.approveBtn, { backgroundColor: "#10B981", opacity: isActing ? 0.5 : 1 }]}
+            onPress={() => handleApprove(item)}
+            disabled={isActing}
+            accessibilityRole="button"
+            accessibilityLabel={`Approve ${formatWorkflow(item.workflow)}`}
+          >
+            <Text style={[styles.btnText, { color: "#fff" }]}>
+              {isActing ? "…" : "✓  Approve"}
+            </Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    );
+  };
+
+  if (loading) {
+    return (
+      <SafeAreaView style={[styles.container, { backgroundColor: theme.background }]}>
+        <View style={styles.center}>
+          <ActivityIndicator size="large" color={theme.text} />
+        </View>
+        <BottomNav active="approvals" pendingApprovals={0} />
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: theme.background }]}>
+      {/* Header */}
+      <View style={[styles.header, { borderBottomColor: theme.border }]}>
+        <View style={styles.headerLeft}>
+          <Text style={[styles.headerTitle, { color: theme.text }]}>Approvals</Text>
+          {approvals.length > 0 && (
+            <View style={styles.headerBadge}>
+              <Text style={styles.headerBadgeText}>{approvals.length}</Text>
+            </View>
+          )}
+        </View>
+        <TouchableOpacity onPress={onRefresh} style={styles.headerBtn} accessibilityLabel="Refresh">
+          <Text style={{ fontSize: 18 }}>↻</Text>
+        </TouchableOpacity>
+      </View>
+
+      {error ? (
+        <View style={styles.center}>
+          <Text style={[styles.emptyText, { color: theme.textMuted }]}>{error}</Text>
+        </View>
+      ) : approvals.length === 0 ? (
+        <View style={styles.center}>
+          <Text style={{ fontSize: 40 }}>✅</Text>
+          <Text style={[styles.emptyText, { color: theme.textMuted }]}>All caught up!</Text>
+          <Text style={[styles.emptySubtext, { color: theme.textMuted }]}>
+            No runs waiting for your approval
+          </Text>
+        </View>
+      ) : (
+        <FlatList
+          data={approvals}
+          keyExtractor={(a) => a.id}
+          renderItem={renderItem}
+          contentContainerStyle={styles.list}
+          refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+        />
+      )}
+
+      {/* Reject reason modal */}
+      <Modal
+        visible={!!rejectTarget}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setRejectTarget(null)}
+      >
+        <TouchableOpacity
+          style={styles.modalOverlay}
+          activeOpacity={1}
+          onPress={() => setRejectTarget(null)}
+        />
+        <View style={[styles.modalSheet, { backgroundColor: theme.surface }]}>
+          <Text style={[styles.modalTitle, { color: theme.text }]}>Reject run</Text>
+          <Text style={[styles.modalSub, { color: theme.textMuted }]}>
+            This action will be logged in the audit trail.
+          </Text>
+          <TextInput
+            style={[styles.reasonInput, { color: theme.text, borderColor: theme.border, backgroundColor: theme.inputBg }]}
+            placeholder="Reason for rejection…"
+            placeholderTextColor={theme.textMuted}
+            value={rejectReason}
+            onChangeText={setRejectReason}
+            multiline
+            maxLength={500}
+            autoFocus
+          />
+          <View style={styles.modalActions}>
+            <TouchableOpacity
+              style={[styles.modalBtn, { borderColor: theme.border }]}
+              onPress={() => setRejectTarget(null)}
+            >
+              <Text style={{ color: theme.textMuted }}>Cancel</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[styles.modalBtn, { backgroundColor: "#EF4444" }]}
+              onPress={handleRejectConfirm}
+            >
+              <Text style={{ color: "#fff", fontWeight: "600" }}>Confirm Reject</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
+
+      <BottomNav active="approvals" pendingApprovals={approvals.length} />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  center: { flex: 1, justifyContent: "center", alignItems: "center", gap: 10 },
+  header: {
+    flexDirection: "row", alignItems: "center", justifyContent: "space-between",
+    paddingHorizontal: 16, paddingVertical: 12, borderBottomWidth: 1,
+  },
+  headerLeft: { flexDirection: "row", alignItems: "center", gap: 8 },
+  headerTitle: { fontSize: 20, fontWeight: "700" },
+  headerBadge: {
+    backgroundColor: "#8B5CF6", borderRadius: 10, minWidth: 20,
+    height: 20, alignItems: "center", justifyContent: "center", paddingHorizontal: 5,
+  },
+  headerBadgeText: { color: "#fff", fontSize: 12, fontWeight: "700" },
+  headerBtn: { padding: 8 },
+  list: { padding: 12, gap: 12 },
+  card: { borderRadius: 12, borderWidth: 2, padding: 14, gap: 12 },
+  cardHeader: { flexDirection: "row", justifyContent: "space-between", alignItems: "flex-start" },
+  cardLeft: { flex: 1, gap: 2 },
+  arrow: { fontSize: 20 },
+  workflow: { fontSize: 15, fontWeight: "600" },
+  time: { fontSize: 12 },
+  message: { fontSize: 14, lineHeight: 20 },
+  context: { fontSize: 12, lineHeight: 18, fontStyle: "italic" },
+  actions: { flexDirection: "row", gap: 10 },
+  btn: { flex: 1, paddingVertical: 10, borderRadius: 8, alignItems: "center" },
+  rejectBtn: { borderWidth: 1, backgroundColor: "transparent" },
+  approveBtn: {},
+  btnText: { fontSize: 14, fontWeight: "600" },
+  emptyText: { fontSize: 16, fontWeight: "600" },
+  emptySubtext: { fontSize: 14 },
+  modalOverlay: {
+    position: "absolute", top: 0, left: 0, right: 0, bottom: 0,
+    backgroundColor: "rgba(0,0,0,0.5)",
+  },
+  modalSheet: {
+    position: "absolute", bottom: 0, left: 0, right: 0,
+    borderTopLeftRadius: 20, borderTopRightRadius: 20,
+    padding: 20, gap: 14,
+  },
+  modalTitle: { fontSize: 18, fontWeight: "700" },
+  modalSub: { fontSize: 13 },
+  reasonInput: {
+    borderWidth: 1, borderRadius: 10, padding: 12,
+    fontSize: 14, minHeight: 80, textAlignVertical: "top",
+  },
+  modalActions: { flexDirection: "row", gap: 10 },
+  modalBtn: {
+    flex: 1, paddingVertical: 12, borderRadius: 10, alignItems: "center", borderWidth: 1,
+  },
+});

--- a/packages/mobile/app/chat.tsx
+++ b/packages/mobile/app/chat.tsx
@@ -7,7 +7,8 @@ import {
 import { router } from "expo-router";
 import { useAppTheme, useAppAuth } from "./_layout";
 import RocketLogo from "../src/components/RocketLogo";
-import { getSessions, getSession, deleteSession, Session, Message } from "../src/api";
+import { BottomNav } from "../src/components/BottomNav";
+import { getSessions, getSession, deleteSession, getPendingApprovals, Session, Message } from "../src/api";
 import { API_BASE, MODELS } from "../src/constants";
 
 export default function ChatScreen() {
@@ -21,6 +22,7 @@ export default function ChatScreen() {
   const [model, setModel] = useState(MODELS[0]);
   const [streaming, setStreaming] = useState(false);
   const [showSidebar, setShowSidebar] = useState(false);
+  const [pendingApprovals, setPendingApprovals] = useState(0);
   const flatListRef = useRef<FlatList>(null);
   const abortRef = useRef<boolean>(false);
 
@@ -28,11 +30,16 @@ export default function ChatScreen() {
     try { setSessions(await getSessions()); } catch {}
   }, []);
 
+  const loadPendingCount = useCallback(async () => {
+    try { setPendingApprovals((await getPendingApprovals()).length); } catch {}
+  }, []);
+
   const loadMessages = useCallback(async (id: string) => {
     try { setMessages(await getSession(id)); } catch {}
   }, []);
 
   useEffect(() => { loadSessions(); }, [loadSessions]);
+  useEffect(() => { loadPendingCount(); }, [loadPendingCount]);
 
   const openSession = async (id: string) => {
     setActiveSession(id);
@@ -258,6 +265,7 @@ export default function ChatScreen() {
           </View>
         </View>
       </KeyboardAvoidingView>
+      <BottomNav active="chat" pendingApprovals={pendingApprovals} />
     </SafeAreaView>
   );
 }

--- a/packages/mobile/app/run/[id].tsx
+++ b/packages/mobile/app/run/[id].tsx
@@ -1,0 +1,563 @@
+import React, { useState, useEffect, useCallback } from "react";
+import {
+  View, Text, ScrollView, TouchableOpacity, StyleSheet,
+  SafeAreaView, ActivityIndicator, Alert, TextInput, Modal,
+} from "react-native";
+import { router, useLocalSearchParams } from "expo-router";
+import { useAppTheme, useAppAuth } from "../_layout";
+import {
+  getRunDetail, approveRun, rejectRun, pauseRun, resumeRun, retryRun,
+  RunDetail, RunStep, Artifact, AuditEntry, RunStatus,
+} from "../../src/api";
+
+const MAX_STEPS_INLINE = 20;
+
+const STATUS_CONFIG: Record<RunStatus, { label: string; color: string; bg: string }> = {
+  running:           { label: "Running",       color: "#3B82F6", bg: "#EFF6FF" },
+  paused:            { label: "Paused",         color: "#F59E0B", bg: "#FFFBEB" },
+  awaiting_approval: { label: "Needs Approval", color: "#8B5CF6", bg: "#F5F3FF" },
+  failed:            { label: "Failed",         color: "#EF4444", bg: "#FEF2F2" },
+  completed:         { label: "Completed",      color: "#10B981", bg: "#ECFDF5" },
+};
+
+const STEP_ICONS: Record<string, string> = {
+  pending: "○", running: "●", done: "✓", failed: "✗",
+};
+const STEP_COLORS: Record<string, string> = {
+  pending: "#9CA3AF", running: "#3B82F6", done: "#10B981", failed: "#EF4444",
+};
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+function formatWorkflow(name: string): string {
+  return name.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function formatBytes(b: number): string {
+  if (b < 1024) return `${b} B`;
+  if (b < 1048576) return `${(b / 1024).toFixed(1)} KB`;
+  return `${(b / 1048576).toFixed(1)} MB`;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function StepRow({ step, theme }: { step: RunStep; theme: any }) {
+  const [expanded, setExpanded] = useState(false);
+  const color = STEP_COLORS[step.status];
+  const icon = STEP_ICONS[step.status];
+  const hasOutput = !!step.output;
+
+  return (
+    <TouchableOpacity
+      onPress={() => hasOutput && setExpanded((e) => !e)}
+      activeOpacity={hasOutput ? 0.7 : 1}
+      accessibilityRole={hasOutput ? "button" : "text"}
+      accessibilityLabel={`${step.name}, ${step.status}${step.latency_ms ? `, ${step.latency_ms}ms` : ""}`}
+      accessibilityState={hasOutput ? { expanded } : undefined}
+    >
+      <View style={styles.stepRow}>
+        <Text style={[styles.stepIcon, { color }]}>{icon}</Text>
+        <View style={styles.stepMid}>
+          <Text style={[styles.stepName, { color: theme.text }]} numberOfLines={expanded ? undefined : 1}>
+            {step.name}
+          </Text>
+          {step.latency_ms !== undefined && (
+            <Text style={[styles.stepMeta, { color: theme.textMuted }]}>{step.latency_ms} ms</Text>
+          )}
+        </View>
+        {hasOutput && (
+          <Text style={[styles.stepChevron, { color: theme.textMuted }]}>{expanded ? "∧" : "∨"}</Text>
+        )}
+      </View>
+      {expanded && step.output && (
+        <ScrollView
+          horizontal
+          style={[styles.outputScroll, { backgroundColor: theme.surfaceAlt }]}
+          showsHorizontalScrollIndicator={false}
+        >
+          <Text style={[styles.outputText, { color: theme.text }]}>{step.output}</Text>
+        </ScrollView>
+      )}
+    </TouchableOpacity>
+  );
+}
+
+function ArtifactRow({ artifact, theme }: { artifact: Artifact; theme: any }) {
+  const [expanded, setExpanded] = useState(false);
+  const isPreviewable = artifact.type === "text" || artifact.type === "json";
+  const isLarge = (artifact.size_bytes ?? 0) > 50_000;
+
+  return (
+    <TouchableOpacity
+      onPress={() => isPreviewable && !isLarge && setExpanded((e) => !e)}
+      activeOpacity={isPreviewable && !isLarge ? 0.7 : 1}
+      accessibilityRole={isPreviewable ? "button" : "text"}
+      accessibilityLabel={`Artifact: ${artifact.name}, type ${artifact.type}`}
+    >
+      <View style={[styles.artifactRow, { borderColor: theme.border }]}>
+        <Text style={styles.artifactIcon}>
+          {{ text: "📄", json: "📋", image: "🖼️", file: "📎" }[artifact.type] ?? "📎"}
+        </Text>
+        <View style={styles.artifactMid}>
+          <Text style={[styles.artifactName, { color: theme.text }]} numberOfLines={1}>
+            {artifact.name}
+          </Text>
+          {artifact.size_bytes !== undefined && (
+            <Text style={[styles.artifactMeta, { color: theme.textMuted }]}>
+              {formatBytes(artifact.size_bytes)}
+              {isLarge ? " — too large to preview" : ""}
+            </Text>
+          )}
+        </View>
+        {isPreviewable && !isLarge && (
+          <Text style={[styles.stepChevron, { color: theme.textMuted }]}>{expanded ? "∧" : "∨"}</Text>
+        )}
+      </View>
+      {expanded && artifact.preview && (
+        <ScrollView
+          style={[styles.outputScroll, { backgroundColor: theme.surfaceAlt }]}
+          nestedScrollEnabled
+        >
+          <Text style={[styles.outputText, { color: theme.text }]}>{artifact.preview}</Text>
+        </ScrollView>
+      )}
+    </TouchableOpacity>
+  );
+}
+
+function AuditRow({ entry, theme }: { entry: AuditEntry; theme: any }) {
+  return (
+    <View style={[styles.auditRow, { borderLeftColor: theme.border }]}>
+      <Text style={[styles.auditAction, { color: theme.text }]}>{entry.action}</Text>
+      <Text style={[styles.auditMeta, { color: theme.textMuted }]}>
+        {entry.actor} · {relativeTime(entry.timestamp)}
+      </Text>
+      {entry.detail && (
+        <Text style={[styles.auditDetail, { color: theme.textMuted }]}>{entry.detail}</Text>
+      )}
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main screen
+// ---------------------------------------------------------------------------
+
+export default function RunDetailScreen() {
+  const { theme } = useAppTheme();
+  const { token } = useAppAuth();
+  const { id } = useLocalSearchParams<{ id: string }>();
+
+  const [run, setRun] = useState<RunDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [acting, setActing] = useState(false);
+  const [showAllSteps, setShowAllSteps] = useState(false);
+  const [showAudit, setShowAudit] = useState(false);
+  const [rejectVisible, setRejectVisible] = useState(false);
+  const [rejectReason, setRejectReason] = useState("");
+
+  const fetchRun = useCallback(async () => {
+    if (!id) return;
+    try {
+      setError(null);
+      setRun(await getRunDetail(id));
+    } catch {
+      setError("Could not load run details.");
+    }
+  }, [id]);
+
+  useEffect(() => {
+    if (!token) { router.replace("/login"); return; }
+    fetchRun().finally(() => setLoading(false));
+  }, [token, fetchRun]);
+
+  // Poll while running
+  useEffect(() => {
+    if (run?.status !== "running") return;
+    const timer = setInterval(fetchRun, 5000);
+    return () => clearInterval(timer);
+  }, [run?.status, fetchRun]);
+
+  const doAction = async (label: string, fn: () => Promise<void>) => {
+    setActing(true);
+    try {
+      await fn();
+      await fetchRun();
+    } catch {
+      Alert.alert("Error", `Could not ${label.toLowerCase()}. Please try again.`);
+    } finally {
+      setActing(false);
+    }
+  };
+
+  const handleApprove = () => {
+    if (!run?.approval) return;
+    Alert.alert("Approve run", "Approve and continue this workflow?", [
+      { text: "Cancel", style: "cancel" },
+      {
+        text: "Approve",
+        onPress: () => doAction("Approve", () => approveRun(run.id, run.approval!.id)),
+      },
+    ]);
+  };
+
+  const handleRejectConfirm = () => {
+    if (!run?.approval || !rejectReason.trim()) {
+      Alert.alert("Reason required", "Enter a reason for rejection.");
+      return;
+    }
+    setRejectVisible(false);
+    doAction("Reject", () => rejectRun(run.id, run.approval!.id, rejectReason.trim()));
+    setRejectReason("");
+  };
+
+  const handlePause = () =>
+    doAction("Pause", () => pauseRun(run!.id));
+
+  const handleResume = () =>
+    doAction("Resume", () => resumeRun(run!.id));
+
+  const handleRetry = () => {
+    Alert.alert("Retry run", "Start this run again from the beginning?", [
+      { text: "Cancel", style: "cancel" },
+      { text: "Retry", onPress: () => doAction("Retry", () => retryRun(run!.id)) },
+    ]);
+  };
+
+  if (loading || !run) {
+    return (
+      <SafeAreaView style={[styles.container, { backgroundColor: theme.background }]}>
+        <View style={[styles.header, { borderBottomColor: theme.border }]}>
+          <TouchableOpacity onPress={() => router.back()} style={styles.backBtn}>
+            <Text style={[styles.backText, { color: theme.text }]}>‹ Back</Text>
+          </TouchableOpacity>
+        </View>
+        <View style={styles.center}>
+          {error
+            ? <Text style={[styles.errorMsg, { color: theme.textMuted }]}>{error}</Text>
+            : <ActivityIndicator size="large" color={theme.text} />}
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  const cfg = STATUS_CONFIG[run.status];
+  const pct = run.steps_total > 0 ? Math.round((run.steps_done / run.steps_total) * 100) : 0;
+  const visibleSteps = showAllSteps ? run.steps : run.steps.slice(0, MAX_STEPS_INLINE);
+  const hiddenCount = run.steps.length - MAX_STEPS_INLINE;
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: theme.background }]}>
+      {/* Header */}
+      <View style={[styles.header, { borderBottomColor: theme.border }]}>
+        <TouchableOpacity onPress={() => router.back()} style={styles.backBtn} accessibilityRole="button" accessibilityLabel="Go back">
+          <Text style={[styles.backText, { color: theme.text }]}>‹ Back</Text>
+        </TouchableOpacity>
+        <Text style={[styles.headerTitle, { color: theme.text }]} numberOfLines={1}>
+          {formatWorkflow(run.workflow)}
+        </Text>
+        {/* Quick pause/resume in header for running runs */}
+        {run.status === "running" && (
+          <TouchableOpacity onPress={handlePause} disabled={acting} style={styles.headerAction} accessibilityLabel="Pause run">
+            <Text style={{ fontSize: 18 }}>{acting ? "…" : "⏸"}</Text>
+          </TouchableOpacity>
+        )}
+        {run.status === "paused" && (
+          <TouchableOpacity onPress={handleResume} disabled={acting} style={styles.headerAction} accessibilityLabel="Resume run">
+            <Text style={{ fontSize: 18 }}>{acting ? "…" : "▶"}</Text>
+          </TouchableOpacity>
+        )}
+        {run.status !== "running" && run.status !== "paused" && <View style={styles.headerAction} />}
+      </View>
+
+      <ScrollView contentContainerStyle={styles.scroll}>
+        {/* Status banner */}
+        <View style={[styles.statusBanner, { backgroundColor: cfg.bg, borderColor: cfg.color }]}>
+          <Text style={[styles.statusLabel, { color: cfg.color }]}>{cfg.label}</Text>
+          {run.steps_total > 0 && (
+            <Text style={[styles.statusSub, { color: cfg.color }]}>
+              {run.steps_done} / {run.steps_total} steps · {pct}%
+            </Text>
+          )}
+        </View>
+
+        {/* Progress bar */}
+        {run.steps_total > 0 && (
+          <View style={[styles.progressTrack, { backgroundColor: theme.surfaceAlt }]}>
+            <View style={[styles.progressFill, { backgroundColor: cfg.color, width: `${pct}%` }]} />
+          </View>
+        )}
+
+        {/* Error message */}
+        {run.error && (
+          <View style={[styles.errorBanner, { backgroundColor: "#FEF2F2", borderColor: "#EF4444" }]}>
+            <Text style={styles.errorBannerTitle}>Error</Text>
+            <Text style={styles.errorBannerText}>{run.error}</Text>
+          </View>
+        )}
+
+        {/* Approval message */}
+        {run.approval && (
+          <View style={[styles.approvalBanner, { backgroundColor: "#F5F3FF", borderColor: "#8B5CF6" }]}>
+            <Text style={styles.approvalTitle}>Approval Requested</Text>
+            <Text style={styles.approvalMsg}>{run.approval.message}</Text>
+            {run.approval.context ? (
+              <Text style={styles.approvalCtx}>{run.approval.context}</Text>
+            ) : null}
+          </View>
+        )}
+
+        {/* Action buttons */}
+        {(run.status === "awaiting_approval" || run.status === "failed") && (
+          <View style={styles.actionRow}>
+            {run.status === "awaiting_approval" && (
+              <>
+                <TouchableOpacity
+                  style={[styles.actionBtn, { borderColor: "#EF4444" }]}
+                  onPress={() => { setRejectReason(""); setRejectVisible(true); }}
+                  disabled={acting}
+                  accessibilityRole="button"
+                  accessibilityLabel="Reject this run"
+                >
+                  <Text style={[styles.actionBtnText, { color: "#EF4444" }]}>✗  Reject</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[styles.actionBtn, { backgroundColor: "#10B981", borderColor: "#10B981", opacity: acting ? 0.5 : 1 }]}
+                  onPress={handleApprove}
+                  disabled={acting}
+                  accessibilityRole="button"
+                  accessibilityLabel="Approve this run"
+                >
+                  <Text style={[styles.actionBtnText, { color: "#fff" }]}>
+                    {acting ? "…" : "✓  Approve"}
+                  </Text>
+                </TouchableOpacity>
+              </>
+            )}
+            {run.status === "failed" && (
+              <TouchableOpacity
+                style={[styles.actionBtn, styles.actionBtnFull, { backgroundColor: "#3B82F6", borderColor: "#3B82F6", opacity: acting ? 0.5 : 1 }]}
+                onPress={handleRetry}
+                disabled={acting}
+                accessibilityRole="button"
+                accessibilityLabel="Retry this run"
+              >
+                <Text style={[styles.actionBtnText, { color: "#fff" }]}>
+                  {acting ? "Retrying…" : "↻  Retry"}
+                </Text>
+              </TouchableOpacity>
+            )}
+          </View>
+        )}
+
+        {/* Steps */}
+        {run.steps.length > 0 && (
+          <View style={styles.section}>
+            <Text style={[styles.sectionTitle, { color: theme.text }]}>Steps</Text>
+            <View style={[styles.sectionCard, { backgroundColor: theme.surface, borderColor: theme.border }]}>
+              {visibleSteps.map((step, i) => (
+                <View key={step.id}>
+                  <StepRow step={step} theme={theme} />
+                  {i < visibleSteps.length - 1 && <View style={[styles.divider, { backgroundColor: theme.border }]} />}
+                </View>
+              ))}
+              {!showAllSteps && hiddenCount > 0 && (
+                <TouchableOpacity
+                  style={styles.showMore}
+                  onPress={() => setShowAllSteps(true)}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Show ${hiddenCount} more steps`}
+                >
+                  <Text style={[styles.showMoreText, { color: theme.textMuted }]}>
+                    Show {hiddenCount} more step{hiddenCount !== 1 ? "s" : ""} ∨
+                  </Text>
+                </TouchableOpacity>
+              )}
+              {showAllSteps && hiddenCount > 0 && (
+                <TouchableOpacity style={styles.showMore} onPress={() => setShowAllSteps(false)}>
+                  <Text style={[styles.showMoreText, { color: theme.textMuted }]}>Show less ∧</Text>
+                </TouchableOpacity>
+              )}
+            </View>
+          </View>
+        )}
+
+        {/* Artifacts */}
+        {run.artifacts.length > 0 && (
+          <View style={styles.section}>
+            <Text style={[styles.sectionTitle, { color: theme.text }]}>
+              Artifacts ({run.artifacts.length})
+            </Text>
+            <View style={[styles.sectionCard, { backgroundColor: theme.surface, borderColor: theme.border }]}>
+              {run.artifacts.map((a, i) => (
+                <View key={a.id}>
+                  <ArtifactRow artifact={a} theme={theme} />
+                  {i < run.artifacts.length - 1 && <View style={[styles.divider, { backgroundColor: theme.border }]} />}
+                </View>
+              ))}
+            </View>
+          </View>
+        )}
+
+        {/* Audit log */}
+        {run.audit_log.length > 0 && (
+          <View style={styles.section}>
+            <TouchableOpacity
+              onPress={() => setShowAudit((s) => !s)}
+              accessibilityRole="button"
+              accessibilityState={{ expanded: showAudit }}
+              accessibilityLabel="Toggle audit log"
+            >
+              <Text style={[styles.sectionTitle, { color: theme.text }]}>
+                Audit log ({run.audit_log.length}) {showAudit ? "∧" : "∨"}
+              </Text>
+            </TouchableOpacity>
+            {showAudit && (
+              <View style={[styles.sectionCard, { backgroundColor: theme.surface, borderColor: theme.border }]}>
+                {run.audit_log.map((e) => (
+                  <AuditRow key={e.id} entry={e} theme={theme} />
+                ))}
+              </View>
+            )}
+          </View>
+        )}
+
+        {/* Timestamps */}
+        <View style={styles.timestamps}>
+          <Text style={[styles.tsText, { color: theme.textMuted }]}>
+            Started {relativeTime(run.created_at)} · Updated {relativeTime(run.updated_at)}
+          </Text>
+        </View>
+      </ScrollView>
+
+      {/* Reject modal */}
+      <Modal visible={rejectVisible} transparent animationType="slide" onRequestClose={() => setRejectVisible(false)}>
+        <TouchableOpacity style={styles.modalOverlay} activeOpacity={1} onPress={() => setRejectVisible(false)} />
+        <View style={[styles.modalSheet, { backgroundColor: theme.surface }]}>
+          <Text style={[styles.modalTitle, { color: theme.text }]}>Reject run</Text>
+          <Text style={[styles.modalSub, { color: theme.textMuted }]}>
+            This action will be recorded in the audit trail.
+          </Text>
+          <TextInput
+            style={[styles.reasonInput, { color: theme.text, borderColor: theme.border, backgroundColor: theme.inputBg }]}
+            placeholder="Reason for rejection…"
+            placeholderTextColor={theme.textMuted}
+            value={rejectReason}
+            onChangeText={setRejectReason}
+            multiline
+            maxLength={500}
+            autoFocus
+          />
+          <View style={styles.modalActions}>
+            <TouchableOpacity style={[styles.modalBtn, { borderColor: theme.border }]} onPress={() => setRejectVisible(false)}>
+              <Text style={{ color: theme.textMuted }}>Cancel</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={[styles.modalBtn, { backgroundColor: "#EF4444" }]} onPress={handleRejectConfirm}>
+              <Text style={{ color: "#fff", fontWeight: "600" }}>Confirm Reject</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  center: { flex: 1, justifyContent: "center", alignItems: "center" },
+  errorMsg: { fontSize: 15, textAlign: "center", paddingHorizontal: 32 },
+  header: {
+    flexDirection: "row", alignItems: "center", paddingHorizontal: 12,
+    paddingVertical: 10, borderBottomWidth: 1, gap: 8,
+  },
+  backBtn: { paddingVertical: 4, paddingRight: 8 },
+  backText: { fontSize: 17 },
+  headerTitle: { flex: 1, fontSize: 16, fontWeight: "600" },
+  headerAction: { width: 36, alignItems: "center" },
+  scroll: { padding: 16, gap: 16, paddingBottom: 40 },
+  statusBanner: {
+    borderRadius: 12, borderWidth: 1.5, paddingHorizontal: 14, paddingVertical: 10, gap: 2,
+  },
+  statusLabel: { fontSize: 16, fontWeight: "700" },
+  statusSub: { fontSize: 13 },
+  progressTrack: { height: 6, borderRadius: 3, overflow: "hidden" },
+  progressFill: { height: 6, borderRadius: 3 },
+  errorBanner: {
+    borderRadius: 10, borderWidth: 1, padding: 12, gap: 4,
+  },
+  errorBannerTitle: { color: "#EF4444", fontWeight: "600", fontSize: 13 },
+  errorBannerText: { color: "#EF4444", fontSize: 13 },
+  approvalBanner: {
+    borderRadius: 10, borderWidth: 1.5, padding: 14, gap: 6,
+  },
+  approvalTitle: { color: "#8B5CF6", fontWeight: "700", fontSize: 14 },
+  approvalMsg: { color: "#5B21B6", fontSize: 14, lineHeight: 20 },
+  approvalCtx: { color: "#7C3AED", fontSize: 12, lineHeight: 18, fontStyle: "italic" },
+  actionRow: { flexDirection: "row", gap: 10 },
+  actionBtn: {
+    flex: 1, paddingVertical: 12, borderRadius: 10, alignItems: "center",
+    borderWidth: 1.5, backgroundColor: "transparent",
+  },
+  actionBtnFull: { flex: 1 },
+  actionBtnText: { fontSize: 15, fontWeight: "600" },
+  section: { gap: 8 },
+  sectionTitle: { fontSize: 15, fontWeight: "600" },
+  sectionCard: { borderRadius: 12, borderWidth: 1, overflow: "hidden" },
+  stepRow: {
+    flexDirection: "row", alignItems: "center", paddingHorizontal: 14,
+    paddingVertical: 10, gap: 10,
+  },
+  stepIcon: { fontSize: 16, width: 20, textAlign: "center" },
+  stepMid: { flex: 1, gap: 1 },
+  stepName: { fontSize: 14 },
+  stepMeta: { fontSize: 11 },
+  stepChevron: { fontSize: 14 },
+  outputScroll: { borderRadius: 6, margin: 8, marginTop: 0, maxHeight: 150, padding: 10 },
+  outputText: { fontSize: 12, fontFamily: "monospace" },
+  divider: { height: 1, marginHorizontal: 14 },
+  showMore: { paddingVertical: 10, alignItems: "center" },
+  showMoreText: { fontSize: 13 },
+  artifactRow: {
+    flexDirection: "row", alignItems: "center", paddingHorizontal: 14,
+    paddingVertical: 10, gap: 10, borderBottomWidth: 0,
+  },
+  artifactIcon: { fontSize: 20 },
+  artifactMid: { flex: 1, gap: 1 },
+  artifactName: { fontSize: 14 },
+  artifactMeta: { fontSize: 11 },
+  auditRow: { paddingLeft: 12, paddingVertical: 8, marginHorizontal: 10, borderLeftWidth: 2, gap: 1 },
+  auditAction: { fontSize: 13, fontWeight: "600" },
+  auditMeta: { fontSize: 11 },
+  auditDetail: { fontSize: 12, fontStyle: "italic" },
+  timestamps: { alignItems: "center" },
+  tsText: { fontSize: 11 },
+  modalOverlay: {
+    position: "absolute", top: 0, left: 0, right: 0, bottom: 0,
+    backgroundColor: "rgba(0,0,0,0.5)",
+  },
+  modalSheet: {
+    position: "absolute", bottom: 0, left: 0, right: 0,
+    borderTopLeftRadius: 20, borderTopRightRadius: 20, padding: 20, gap: 14,
+  },
+  modalTitle: { fontSize: 18, fontWeight: "700" },
+  modalSub: { fontSize: 13 },
+  reasonInput: {
+    borderWidth: 1, borderRadius: 10, padding: 12, fontSize: 14,
+    minHeight: 80, textAlignVertical: "top",
+  },
+  modalActions: { flexDirection: "row", gap: 10 },
+  modalBtn: {
+    flex: 1, paddingVertical: 12, borderRadius: 10, alignItems: "center", borderWidth: 1,
+  },
+});

--- a/packages/mobile/app/runs.tsx
+++ b/packages/mobile/app/runs.tsx
@@ -1,0 +1,257 @@
+import React, { useState, useEffect, useCallback } from "react";
+import {
+  View, Text, FlatList, TouchableOpacity, StyleSheet,
+  SafeAreaView, RefreshControl, ActivityIndicator,
+} from "react-native";
+import { router } from "expo-router";
+import { useAppTheme, useAppAuth } from "./_layout";
+import { BottomNav } from "../src/components/BottomNav";
+import { getRuns, getPendingApprovals, Run, RunStatus } from "../src/api";
+
+type Filter = "all" | "active" | "needs_action" | "completed";
+
+const STATUS_CONFIG: Record<RunStatus, { label: string; color: string; dot: string }> = {
+  running:           { label: "Running",          color: "#3B82F6", dot: "🔵" },
+  paused:            { label: "Paused",            color: "#F59E0B", dot: "🟡" },
+  awaiting_approval: { label: "Needs Approval",    color: "#8B5CF6", dot: "🟣" },
+  failed:            { label: "Failed",            color: "#EF4444", dot: "🔴" },
+  completed:         { label: "Completed",         color: "#10B981", dot: "🟢" },
+};
+
+function needsAction(status: RunStatus) {
+  return status === "awaiting_approval" || status === "failed";
+}
+
+function isActive(status: RunStatus) {
+  return status === "running" || status === "paused";
+}
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+function formatWorkflow(name: string): string {
+  return name.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export default function RunsScreen() {
+  const { theme } = useAppTheme();
+  const { token } = useAppAuth();
+  const [runs, setRuns] = useState<Run[]>([]);
+  const [pendingCount, setPendingCount] = useState(0);
+  const [filter, setFilter] = useState<Filter>("all");
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    try {
+      setError(null);
+      const [runList, approvals] = await Promise.all([getRuns(), getPendingApprovals()]);
+      setRuns(runList);
+      setPendingCount(approvals.length);
+    } catch {
+      setError("Could not load runs. Pull down to retry.");
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!token) { router.replace("/login"); return; }
+    fetchData().finally(() => setLoading(false));
+  }, [token, fetchData]);
+
+  // Poll running runs every 10 s
+  useEffect(() => {
+    const hasRunning = runs.some((r) => r.status === "running");
+    if (!hasRunning) return;
+    const id = setInterval(fetchData, 10000);
+    return () => clearInterval(id);
+  }, [runs, fetchData]);
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await fetchData();
+    setRefreshing(false);
+  }, [fetchData]);
+
+  const filtered = runs.filter((r) => {
+    if (filter === "active") return isActive(r.status);
+    if (filter === "needs_action") return needsAction(r.status);
+    if (filter === "completed") return r.status === "completed";
+    return true;
+  });
+
+  const FILTERS: { key: Filter; label: string }[] = [
+    { key: "all",          label: "All" },
+    { key: "active",       label: "Active" },
+    { key: "needs_action", label: "Needs Action" },
+    { key: "completed",    label: "Done" },
+  ];
+
+  const renderRun = ({ item }: { item: Run }) => {
+    const cfg = STATUS_CONFIG[item.status];
+    const pct = item.steps_total > 0
+      ? Math.round((item.steps_done / item.steps_total) * 100)
+      : 0;
+    return (
+      <TouchableOpacity
+        style={[styles.card, { backgroundColor: theme.surface, borderColor: theme.border }]}
+        onPress={() => router.push({ pathname: "/run/[id]", params: { id: item.id } })}
+        accessibilityRole="button"
+        accessibilityLabel={`${formatWorkflow(item.workflow)} run, status ${cfg.label}`}
+      >
+        <View style={styles.cardHeader}>
+          <View style={styles.cardLeft}>
+            <Text style={[styles.workflow, { color: theme.text }]} numberOfLines={1}>
+              {formatWorkflow(item.workflow)}
+            </Text>
+            <View style={styles.statusRow}>
+              <View style={[styles.statusDot, { backgroundColor: cfg.color }]} />
+              <Text style={[styles.statusLabel, { color: cfg.color }]}>{cfg.label}</Text>
+            </View>
+          </View>
+          <View style={styles.cardRight}>
+            <Text style={[styles.timestamp, { color: theme.textMuted }]}>
+              {relativeTime(item.updated_at)}
+            </Text>
+            <Text style={{ color: theme.textMuted, fontSize: 18 }}>›</Text>
+          </View>
+        </View>
+
+        {/* Progress bar */}
+        {item.steps_total > 0 && (
+          <View style={styles.progressWrap}>
+            <View style={[styles.progressTrack, { backgroundColor: theme.surfaceAlt }]}>
+              <View style={[styles.progressFill, { backgroundColor: cfg.color, width: `${pct}%` }]} />
+            </View>
+            <Text style={[styles.progressText, { color: theme.textMuted }]}>
+              {item.steps_done}/{item.steps_total} steps
+            </Text>
+          </View>
+        )}
+
+        {item.artifact_count > 0 && (
+          <Text style={[styles.artifacts, { color: theme.textMuted }]}>
+            {item.artifact_count} artifact{item.artifact_count !== 1 ? "s" : ""}
+          </Text>
+        )}
+
+        {item.error && (
+          <Text style={[styles.errorText, { color: "#EF4444" }]} numberOfLines={1}>
+            {item.error}
+          </Text>
+        )}
+      </TouchableOpacity>
+    );
+  };
+
+  if (loading) {
+    return (
+      <SafeAreaView style={[styles.container, { backgroundColor: theme.background }]}>
+        <View style={styles.center}>
+          <ActivityIndicator size="large" color={theme.text} />
+        </View>
+        <BottomNav active="runs" pendingApprovals={pendingCount} />
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: theme.background }]}>
+      {/* Header */}
+      <View style={[styles.header, { borderBottomColor: theme.border }]}>
+        <Text style={[styles.headerTitle, { color: theme.text }]}>Runs</Text>
+        <TouchableOpacity onPress={onRefresh} style={styles.headerBtn} accessibilityLabel="Refresh runs">
+          <Text style={{ fontSize: 18 }}>↻</Text>
+        </TouchableOpacity>
+      </View>
+
+      {/* Filter chips */}
+      <View style={[styles.filters, { borderBottomColor: theme.border }]}>
+        {FILTERS.map((f) => (
+          <TouchableOpacity
+            key={f.key}
+            style={[
+              styles.chip,
+              { borderColor: theme.border, backgroundColor: filter === f.key ? theme.text : "transparent" },
+            ]}
+            onPress={() => setFilter(f.key)}
+            accessibilityRole="radio"
+            accessibilityState={{ selected: filter === f.key }}
+          >
+            <Text style={[styles.chipText, { color: filter === f.key ? theme.background : theme.textMuted }]}>
+              {f.label}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      {error ? (
+        <View style={styles.center}>
+          <Text style={[styles.emptyText, { color: theme.textMuted }]}>{error}</Text>
+        </View>
+      ) : filtered.length === 0 ? (
+        <View style={styles.center}>
+          <Text style={{ fontSize: 40 }}>⚡</Text>
+          <Text style={[styles.emptyText, { color: theme.textMuted }]}>
+            {filter === "all" ? "No runs yet" : `No ${filter.replace("_", " ")} runs`}
+          </Text>
+        </View>
+      ) : (
+        <FlatList
+          data={filtered}
+          keyExtractor={(r) => r.id}
+          renderItem={renderRun}
+          contentContainerStyle={styles.list}
+          refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+        />
+      )}
+
+      <BottomNav active="runs" pendingApprovals={pendingCount} />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  center: { flex: 1, justifyContent: "center", alignItems: "center", gap: 12 },
+  header: {
+    flexDirection: "row", alignItems: "center", justifyContent: "space-between",
+    paddingHorizontal: 16, paddingVertical: 12, borderBottomWidth: 1,
+  },
+  headerTitle: { fontSize: 20, fontWeight: "700" },
+  headerBtn: { padding: 8 },
+  filters: {
+    flexDirection: "row", paddingHorizontal: 12, paddingVertical: 8,
+    gap: 8, borderBottomWidth: 1,
+  },
+  chip: {
+    paddingHorizontal: 10, paddingVertical: 4, borderRadius: 16, borderWidth: 1,
+  },
+  chipText: { fontSize: 12, fontWeight: "500" },
+  list: { padding: 12, gap: 10 },
+  card: {
+    borderRadius: 12, borderWidth: 1, padding: 14, gap: 10,
+  },
+  cardHeader: { flexDirection: "row", justifyContent: "space-between", alignItems: "flex-start" },
+  cardLeft: { flex: 1, gap: 4 },
+  cardRight: { alignItems: "flex-end", gap: 4, paddingLeft: 8 },
+  workflow: { fontSize: 15, fontWeight: "600" },
+  statusRow: { flexDirection: "row", alignItems: "center", gap: 6 },
+  statusDot: { width: 8, height: 8, borderRadius: 4 },
+  statusLabel: { fontSize: 12, fontWeight: "500" },
+  timestamp: { fontSize: 12 },
+  progressWrap: { gap: 4 },
+  progressTrack: { height: 4, borderRadius: 2, overflow: "hidden" },
+  progressFill: { height: 4, borderRadius: 2 },
+  progressText: { fontSize: 11 },
+  artifacts: { fontSize: 11 },
+  errorText: { fontSize: 12 },
+  emptyText: { fontSize: 15 },
+});

--- a/packages/mobile/src/api.ts
+++ b/packages/mobile/src/api.ts
@@ -42,3 +42,99 @@ export async function getSession(id: string): Promise<Message[]> {
 export async function deleteSession(id: string): Promise<void> {
   await api.delete(`/api/chat/sessions/${id}`);
 }
+
+// ---------------------------------------------------------------------------
+// Autonomous run monitoring
+// ---------------------------------------------------------------------------
+
+export type RunStatus = "running" | "paused" | "awaiting_approval" | "failed" | "completed";
+
+export interface Run {
+  id: string;
+  workflow: string;
+  status: RunStatus;
+  created_at: string;
+  updated_at: string;
+  steps_total: number;
+  steps_done: number;
+  artifact_count: number;
+  error?: string;
+}
+
+export interface RunStep {
+  id: string;
+  name: string;
+  status: "pending" | "running" | "done" | "failed";
+  output?: string;
+  started_at?: string;
+  finished_at?: string;
+  latency_ms?: number;
+}
+
+export interface Artifact {
+  id: string;
+  name: string;
+  type: "text" | "json" | "image" | "file";
+  preview?: string;
+  size_bytes?: number;
+  url?: string;
+}
+
+export interface ApprovalRequest {
+  id: string;
+  run_id: string;
+  workflow: string;
+  message: string;
+  context?: string;
+  created_at: string;
+}
+
+export interface AuditEntry {
+  id: string;
+  action: string;
+  actor: string;
+  timestamp: string;
+  detail?: string;
+}
+
+export interface RunDetail extends Run {
+  steps: RunStep[];
+  artifacts: Artifact[];
+  approval?: ApprovalRequest;
+  audit_log: AuditEntry[];
+}
+
+export async function getRuns(): Promise<Run[]> {
+  const res = await api.get("/api/runs");
+  return res.data.runs ?? [];
+}
+
+export async function getRunDetail(id: string): Promise<RunDetail> {
+  const res = await api.get(`/api/runs/${id}`);
+  return res.data;
+}
+
+export async function getPendingApprovals(): Promise<ApprovalRequest[]> {
+  const res = await api.get("/api/runs/approvals");
+  return res.data.approvals ?? [];
+}
+
+export async function approveRun(runId: string, approvalId: string, note?: string): Promise<void> {
+  await api.post(`/api/runs/${runId}/approve`, { approval_id: approvalId, note });
+}
+
+export async function rejectRun(runId: string, approvalId: string, reason: string): Promise<void> {
+  await api.post(`/api/runs/${runId}/reject`, { approval_id: approvalId, reason });
+}
+
+export async function pauseRun(runId: string): Promise<void> {
+  await api.post(`/api/runs/${runId}/pause`);
+}
+
+export async function resumeRun(runId: string): Promise<void> {
+  await api.post(`/api/runs/${runId}/resume`);
+}
+
+export async function retryRun(runId: string): Promise<void> {
+  await api.post(`/api/runs/${runId}/retry`);
+}

--- a/packages/mobile/src/components/BottomNav.tsx
+++ b/packages/mobile/src/components/BottomNav.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
+import { router } from "expo-router";
+import { useAppTheme } from "../../app/_layout";
+
+export type NavTab = "chat" | "runs" | "approvals";
+
+interface Props {
+  active: NavTab;
+  pendingApprovals?: number;
+}
+
+const TABS: { key: NavTab; label: string; icon: string; route: string }[] = [
+  { key: "chat",      label: "Chat",      icon: "💬", route: "/chat" },
+  { key: "runs",      label: "Runs",      icon: "⚡", route: "/runs" },
+  { key: "approvals", label: "Approvals", icon: "✅", route: "/approvals" },
+];
+
+export function BottomNav({ active, pendingApprovals = 0 }: Props) {
+  const { theme } = useAppTheme();
+
+  return (
+    <View style={[styles.bar, { backgroundColor: theme.surface, borderTopColor: theme.border }]}>
+      {TABS.map((tab) => {
+        const isActive = tab.key === active;
+        const showBadge = tab.key === "approvals" && pendingApprovals > 0;
+        return (
+          <TouchableOpacity
+            key={tab.key}
+            style={styles.tab}
+            onPress={() => { if (!isActive) router.replace(tab.route as any); }}
+            accessibilityRole="tab"
+            accessibilityState={{ selected: isActive }}
+            accessibilityLabel={tab.label}
+          >
+            <View style={styles.iconWrap}>
+              <Text style={styles.icon}>{tab.icon}</Text>
+              {showBadge && (
+                <View style={styles.badge}>
+                  <Text style={styles.badgeText}>
+                    {pendingApprovals > 9 ? "9+" : String(pendingApprovals)}
+                  </Text>
+                </View>
+              )}
+            </View>
+            <Text style={[styles.label, { color: isActive ? theme.text : theme.textMuted }]}>
+              {tab.label}
+            </Text>
+          </TouchableOpacity>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  bar: {
+    flexDirection: "row",
+    borderTopWidth: 1,
+    paddingBottom: 4,
+  },
+  tab: {
+    flex: 1,
+    alignItems: "center",
+    paddingVertical: 8,
+    gap: 2,
+  },
+  iconWrap: {
+    position: "relative",
+    width: 28,
+    height: 28,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  icon: { fontSize: 20 },
+  badge: {
+    position: "absolute",
+    top: -4,
+    right: -8,
+    backgroundColor: "#EF4444",
+    borderRadius: 8,
+    minWidth: 16,
+    height: 16,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 3,
+  },
+  badgeText: { color: "#fff", fontSize: 10, fontWeight: "700" },
+  label: { fontSize: 11, fontWeight: "500" },
+});


### PR DESCRIPTION
## Summary

Closes #160

- **Runs list screen** (`app/runs.tsx`): filter chips (All / Active / Needs Action / Done), status badges with color coding, progress bars, artifact counts, 10 s live polling for active runs, pull-to-refresh
- **Run detail screen** (`app/run/[id].tsx`): color-coded status banner, step list (collapsible output, capped at 20 inline + "Show N more"), artifact previews (50 KB size gate), collapsible audit log, action buttons — Approve/Reject (awaiting approval), Pause/Resume (running/paused), Retry (failed), 5 s auto-poll while running
- **Approvals queue** (`app/approvals.tsx`): one-tap approve with Alert confirm, reject modal requiring a reason (logged to audit trail), badge count in header
- **BottomNav** (`src/components/BottomNav.tsx`): shared Chat / Runs / Approvals tab bar with red badge on Approvals when pending count > 0
- **API layer** (`src/api.ts`): `getRuns`, `getRunDetail`, `getPendingApprovals`, `approveRun`, `rejectRun`, `pauseRun`, `resumeRun`, `retryRun`; full TypeScript types for `Run`, `RunDetail`, `RunStep`, `Artifact`, `ApprovalRequest`, `AuditEntry`
- **Chat screen** (`app/chat.tsx`): wired into BottomNav with pending approval count badge

## Test plan

- [ ] Launch Expo dev build; verify Chat tab shows BottomNav with Approvals badge when approvals are pending
- [ ] Navigate to Runs tab; confirm filter chips, status colors, and progress bars render correctly
- [ ] Tap a run card; confirm detail screen loads steps, artifacts, and audit log
- [ ] On a run in `awaiting_approval` state: tap Approve → Alert confirm → status updates; tap Reject → modal appears → reason required → submit → removed from queue
- [ ] On a `running` run: confirm 5 s auto-poll refreshes step progress
- [ ] On a `failed` run: confirm Retry button is visible and tappable
- [ ] Confirm large artifact previews (> 50 KB) show degraded "too large to preview" message
- [ ] Confirm step lists > 20 steps truncate with "Show N more steps" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)