### PR TITLE
Scaffold Panacea deployment: terraform, CI/CD, and release-pipeline gaps

### DIFF
--- a/.github/workflows/deploy-panacea.yml
+++ b/.github/workflows/deploy-panacea.yml
@@ -1,0 +1,145 @@
+name: Deploy Panacea
+
+# Continuous deployment for the Panacea product line (web app, backend,
+# cookbook/docs). Pushing to `develop` auto-deploys staging; production is
+# manual via workflow_dispatch. This is separate from `deploy.yml`, which
+# deploys the original anote-ai ECS/Fargate stack.
+#
+# VS Code extension / CLI / desktop app releases are handled by
+# `release.yml` on version tags — unrelated to this workflow.
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - "packages/web/**"
+      - "packages/backend/**"
+      - "packages/docs/**"
+      - "terraform/panacea/**"
+      - ".github/workflows/deploy-panacea.yml"
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment"
+        required: true
+        default: staging
+        type: choice
+        options: [production, staging]
+
+concurrency:
+  group: deploy-panacea-${{ github.event.inputs.environment || 'staging' }}
+  cancel-in-progress: false
+
+jobs:
+  deploy-backend:
+    name: Deploy backend to EC2
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment || 'staging' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy over SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.PANACEA_EC2_HOST }}
+          username: ${{ secrets.PANACEA_EC2_USER }}
+          key: ${{ secrets.PANACEA_EC2_SSH_KEY }}
+          script: |
+            set -e
+            cd ${{ secrets.PANACEA_EC2_APP_DIR }}
+            git fetch origin
+            git checkout ${{ github.sha }}
+            docker compose -f docker-compose.panacea.yml build backend
+            docker compose -f docker-compose.panacea.yml up -d backend
+            docker image prune -f
+
+  deploy-web:
+    name: Deploy web app to S3/CloudFront
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment || 'staging' }}
+    needs: deploy-backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20.19.0"
+          cache: npm
+          cache-dependency-path: packages/web/package-lock.json
+
+      - name: Install dependencies
+        working-directory: packages/web
+        run: npm ci
+
+      - name: Build
+        working-directory: packages/web
+        run: npm run build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION || 'us-east-1' }}
+
+      - name: Sync to S3
+        run: |
+          aws s3 sync packages/web/dist/ s3://${{ secrets.PANACEA_S3_WEB_BUCKET }} --delete \
+            --cache-control "public, max-age=31536000, immutable" \
+            --exclude "index.html" --exclude "*.json"
+          aws s3 cp packages/web/dist/index.html s3://${{ secrets.PANACEA_S3_WEB_BUCKET }}/index.html \
+            --cache-control "no-cache, no-store, must-revalidate"
+          aws s3 sync packages/web/dist/ s3://${{ secrets.PANACEA_S3_WEB_BUCKET }} \
+            --exclude "*" --include "*.json" --cache-control "no-cache"
+
+      - name: Invalidate CloudFront
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ secrets.PANACEA_CLOUDFRONT_WEB_DISTRIBUTION_ID }} --paths "/*"
+
+  deploy-cookbook:
+    name: Deploy cookbook/docs to S3/CloudFront
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment || 'staging' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install MkDocs
+        run: pip install mkdocs-material
+
+      - name: Build docs
+        working-directory: packages/docs
+        run: mkdocs build --strict
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION || 'us-east-1' }}
+
+      - name: Sync to S3
+        run: |
+          aws s3 sync packages/docs/site/ s3://${{ secrets.PANACEA_S3_COOKBOOK_BUCKET }} --delete \
+            --cache-control "public, max-age=3600"
+
+      - name: Invalidate CloudFront
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ secrets.PANACEA_CLOUDFRONT_COOKBOOK_DISTRIBUTION_ID }} --paths "/*"
+
+  notify:
+    name: Notify on Failure
+    runs-on: ubuntu-latest
+    needs: [deploy-backend, deploy-web, deploy-cookbook]
+    if: failure()
+    steps:
+      - uses: slackapi/slack-github-action@v1
+        continue-on-error: true
+        with:
+          payload: |
+            {"text": "Panacea deploy FAILED on `${{ github.ref_name }}` — ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,9 @@
 name: Release
 
-# Triggered by pushing a tag like v1.2.3. Publishes the CLI to npm, the
-# VS Code extension to the Marketplace, and the desktop app to GitHub Releases.
+# Triggered by pushing a tag like v1.2.3. Publishes the CLI, TypeScript SDK
+# to npm, the Python SDK to PyPI, builds the mobile app via EAS, publishes
+# the VS Code extension to the Marketplace, and the desktop app to GitHub
+# Releases.
 on:
   push:
     tags:
@@ -25,6 +27,61 @@ jobs:
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-sdk-ts:
+    name: Publish TypeScript SDK to npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.19.0
+          registry-url: "https://registry.npmjs.org"
+      - working-directory: packages/sdk
+        run: npm install
+      - working-directory: packages/sdk
+        run: npm run build
+      - working-directory: packages/sdk
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-sdk-py:
+    name: Publish Python SDK to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - working-directory: packages/sdk-py
+        run: pip install build
+      - working-directory: packages/sdk-py
+        run: python -m build
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: packages/sdk-py/dist
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+  publish-mobile:
+    name: Build mobile app (EAS)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.19.0
+      - working-directory: packages/mobile
+        run: npm install
+      - run: npm install -g eas-cli
+      # `eas submit` needs Apple/Google credentials wired into
+      # packages/mobile/eas.json (currently an empty submit.production
+      # stub) — see DEPLOYMENT.md. Until that's filled in, this only
+      # builds the binaries; add `--auto-submit` once submit is configured.
+      - working-directory: packages/mobile
+        run: eas build --platform all --profile production --non-interactive
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
 
   publish-vscode:
     name: Publish VS Code extension

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ Thumbs.db
 # Docker
 .docker/
 
+# Elastic Beanstalk (created locally by `eb init`, machine/user-specific)
+.elasticbeanstalk/
+
 # Secrets
 *.pem
 *.key

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
 # Terraform
-terraform/.terraform/
-terraform/*.tfstate
-terraform/*.tfstate.*
-terraform/*.tfvars
-terraform/.terraform.lock.hcl
-terraform/crash.log
+terraform/**/.terraform/
+terraform/**/*.tfstate
+terraform/**/*.tfstate.*
+terraform/**/*.tfvars
+terraform/**/.terraform.lock.hcl
+terraform/**/crash.log
 
 # Node
 node_modules/
@@ -53,4 +53,5 @@ Thumbs.db
 *.key
 .env.local
 .env.production
+.env.panacea
 .claude/worktrees/

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -41,7 +41,9 @@ Panacea's AWS bill under the ≤$100/month target — see
    create `.env.panacea` (gitignored) with the backend's runtime secrets
    (`JWT_SECRET_KEY`, `ANTHROPIC_API_KEY`, DB connection info for whatever
    MySQL/Redis/Tika the instance already runs for the existing chatbot,
-   `PANACEA_ORIGIN_VERIFY` from step 4, etc).
+   `PANACEA_ORIGIN_VERIFY` from step 4, etc). If chat/document persistence
+   lands on a MySQL backend (see #259), also set
+   `PERSISTENCE_BACKEND=mysql` alongside the `DB_*` vars here.
 6. **Set GitHub Actions secrets** (repo Settings → Environments →
    `staging`/`production`):
    - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION` (shared with

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -103,29 +103,40 @@ which no amount of pipeline scaffolding can substitute for.
 
 ## Legacy manual deployment (anote.ai / chat.anote.ai)
 
+This is the **root-level `backend/` + `frontend/` folders** — not
+`packages/backend`/`packages/web`, and not the Panacea stack above.
+`backend/app.py` hardcodes `https://chat.anote.ai` as an allowed CORS
+origin, which is how you can tell these are the ones actually serving it.
+
 Tutorial reference: [How to deploy a website on AWS with Docker, Flask, React](https://adamraudonis.medium.com/how-to-deploy-a-website-on-aws-with-docker-flask-react-from-scratch-d0845ebd9da4)
 
 ### Frontend — AWS S3
 
 Prod URL: `https://anote-frontend.s3.amazonaws.com/index.html`
 
-From the frontend folder:
+From the `frontend/` folder. The app reads its backend URL from
+`REACT_APP_BACK_END_HOST` (see `frontend/src/http/RequestConfig.js`) — an
+earlier version of this guide said `REACT_APP_API_ENDPOINT`, which the
+frontend code doesn't actually read, so it silently no-ops and leaves the
+API endpoint blank. Use the name below.
 
 **Staging**
 ```bash
-export REACT_APP_API_ENDPOINT=https://api.tryanote-staging.com
+export REACT_APP_BACK_END_HOST=https://api.tryanote-staging.com
 npm run build
 aws s3 sync build/ s3://anote-staging-frontend --acl public-read
 ```
 
 **Prod**
 ```bash
-REACT_APP_API_ENDPOINT=https://api.anote.ai npm run build && \
+REACT_APP_BACK_END_HOST=https://api.anote.ai npm run build && \
 for file in ./build/static/js/*.js; do uglifyjs "$file" --compress --mangle -o "$file"; done && \
 aws s3 sync build/ s3://anote-product-frontend --acl public-read
 ```
 
-Chatbot frontend bucket: `anote-chatbot-frontend`.
+Chatbot frontend bucket: `anote-chatbot-frontend` — same build command,
+`REACT_APP_BACK_END_HOST` pointed at whatever backend URL chat.anote.ai's
+CORS config expects (see `backend/app.py`'s `ORIGINS` list).
 
 ### Documentation
 
@@ -146,7 +157,7 @@ export APP_ENV=local
 flask run
 ```
 
-Make sure `requirements.txt` is up to date. From the server folder:
+Make sure `requirements.txt` is up to date. From the `backend/` folder:
 ```bash
 docker build -t anote-backend . --platform linux/amd64
 docker run -p 5000:5000 anote-backend   # manual smoke test against the React frontend
@@ -162,10 +173,12 @@ If not logged into AWS/ECR:
 aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 730335449740.dkr.ecr.us-east-1.amazonaws.com
 ```
 
-Then from `server/aws_deploy` (contains `Dockerrun.aws.json`, which references
-the ECR image):
+Then from `backend/aws_deploy` (contains `Dockerrun.aws.json`, which
+references the ECR image — this file wasn't checked into the repo before
+and `eb deploy` couldn't run from a fresh checkout without it; it now is):
 ```bash
-eb init   # select Anote2
+eb init   # select Anote2 — this also writes .elasticbeanstalk/config.yml,
+          # which is developer-machine-local and (correctly) not committed
 eb deploy
 ```
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -65,8 +65,39 @@ Component | How it ships
 Web app (`packages/web`) | `deploy-panacea.yml`, on push to `develop`
 Backend (`packages/backend`) | `deploy-panacea.yml`, on push to `develop`
 Cookbook/docs (`packages/docs`) | `deploy-panacea.yml`, on push to `develop`
-CLI, VS Code extension, desktop app | `release.yml`, on `v*` git tags (unchanged, no AWS involved)
-Mobile app | **TODO** — no CI yet; needs an EAS (Expo) build/submit step once App Store/Play Store credentials exist
+CLI (`packages/cli`, npm) | `release.yml`, on `v*` git tags
+TypeScript SDK (`packages/sdk`, npm) | `release.yml`, on `v*` git tags
+Python SDK (`packages/sdk-py`, PyPI `anote-sdk`) | `release.yml`, on `v*` git tags
+VS Code extension | `release.yml`, on `v*` git tags
+Desktop app | `release.yml`, on `v*` git tags, GitHub Releases on `anote-ai/Panacea`
+Mobile app | `release.yml`, on `v*` git tags — builds via EAS; **submit is not automatic yet** (see below)
+
+### Release-track (`release.yml`) secrets
+
+- `NPM_TOKEN` — publishes both the CLI and the TypeScript SDK (two separate
+  npm packages, one token).
+- `PYPI_API_TOKEN` — PyPI API token scoped to the `anote-sdk` project.
+- `VSCE_PAT` — VS Code Marketplace personal access token for the `Anote`
+  publisher.
+- `GITHUB_TOKEN` — provided automatically by Actions; used by
+  `electron-forge publish` to create the desktop app's GitHub Release on
+  this repo (`anote-ai/Panacea` — `packages/desktop/forge.config.js` was
+  previously pointed at the old `Autonomous-Intelligence` repo name, fixed).
+- `EXPO_TOKEN` — Expo access token so `eas build` can run non-interactively
+  in CI.
+
+**Mobile app remaining action item**: `packages/mobile/eas.json`'s
+`submit.production` block is still empty, so `release.yml`'s
+`publish-mobile` job only builds the iOS/Android binaries — it does not
+submit them to the App Store / Play Store. To turn on auto-submit:
+1. Fill in `submit.production.ios` (`appleId`, `ascAppId`, `appleTeamId`)
+   and `submit.production.android` (`serviceAccountKeyPath`, or store the
+   key as an EAS secret) in `eas.json`, per the
+   [EAS submit docs](https://docs.expo.dev/submit/introduction/).
+2. Add `--auto-submit` to the `eas build` command in the `publish-mobile`
+   job.
+This needs your actual Apple Developer / Google Play Console credentials,
+which no amount of pipeline scaffolding can substitute for.
 
 ## Legacy manual deployment (anote.ai / chat.anote.ai)
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,167 @@
+# Deployment Guide
+
+This repo now has two deployment tracks:
+
+1. **Legacy manual track** (`anote.ai` / `chat.anote.ai`, the original
+   Autonomous Intelligence product) — S3 sync + Elastic Beanstalk, run by
+   hand from a developer's terminal. See "Legacy manual deployment" below
+   for the existing runbook; it's unchanged.
+2. **Panacea track** (this section) — the developer-facing product (web
+   app, VS Code extension, CLI, desktop app, mobile app, cookbook/docs) on
+   its own domain, deployed automatically via Terraform + GitHub Actions.
+
+Both tracks run in the same AWS account (`730335449740`, `us-east-1`) as
+the existing infrastructure — Panacea doesn't need a new account, just new
+S3/CloudFront/Route53 resources plus reuse of the existing Private Chatbot
+EC2 instance for compute. That reuse (no new RDS/ALB/Fargate) is what keeps
+Panacea's AWS bill under the ≤$100/month target — see
+`terraform/panacea/README.md` for the line-item breakdown.
+
+## Panacea: one-time setup
+
+1. **Buy the domain** on GoDaddy.
+2. **Provision AWS resources**:
+   ```bash
+   cd terraform/panacea
+   terraform init -backend-config="bucket=<state-bucket>" -backend-config="key=panacea/terraform.tfstate"
+   export TF_VAR_domain_name="yournewdomain.com"
+   export TF_VAR_ec2_instance_name_tag="private-chatbot"  # match the real Name tag on that EC2 instance
+   terraform apply
+   ```
+3. **Connect the domain** — either point GoDaddy's nameservers at the
+   `route53_name_servers` output (default), or add the CNAME records from
+   `manual_dns_records` by hand if GoDaddy should stay authoritative. Full
+   walkthrough in `terraform/panacea/README.md`.
+4. **Harden the backend port**: set the `origin_verify_header_value`
+   output as an env var the Flask app checks against the
+   `X-Panacea-Origin-Verify` request header, rejecting anything else — the
+   EC2 security group has to allow the backend port from `0.0.0.0/0` since
+   CloudFront has no fixed IP range.
+5. **One-time instance setup**: on the EC2 instance, clone this repo and
+   create `.env.panacea` (gitignored) with the backend's runtime secrets
+   (`JWT_SECRET_KEY`, `ANTHROPIC_API_KEY`, DB connection info for whatever
+   MySQL/Redis/Tika the instance already runs for the existing chatbot,
+   `PANACEA_ORIGIN_VERIFY` from step 4, etc).
+6. **Set GitHub Actions secrets** (repo Settings → Environments →
+   `staging`/`production`):
+   - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION` (shared with
+     the existing `deploy.yml`)
+   - `PANACEA_EC2_HOST`, `PANACEA_EC2_USER`, `PANACEA_EC2_SSH_KEY`,
+     `PANACEA_EC2_APP_DIR` (path this repo is checked out to on the instance)
+   - `PANACEA_S3_WEB_BUCKET`, `PANACEA_CLOUDFRONT_WEB_DISTRIBUTION_ID`
+     (from the `web_s3_bucket` / CloudFront `web` distribution outputs)
+   - `PANACEA_S3_COOKBOOK_BUCKET`, `PANACEA_CLOUDFRONT_COOKBOOK_DISTRIBUTION_ID`
+     (from the `cookbook_s3_bucket` / `cookbook` distribution outputs)
+
+## Panacea: day-to-day deploys
+
+Push to `develop` → `.github/workflows/deploy-panacea.yml` auto-deploys
+staging (backend to EC2 over SSH, web app + cookbook to S3/CloudFront).
+Production is manual: Actions → "Deploy Panacea" → Run workflow →
+`environment: production`.
+
+Component | How it ships
+---|---
+Web app (`packages/web`) | `deploy-panacea.yml`, on push to `develop`
+Backend (`packages/backend`) | `deploy-panacea.yml`, on push to `develop`
+Cookbook/docs (`packages/docs`) | `deploy-panacea.yml`, on push to `develop`
+CLI, VS Code extension, desktop app | `release.yml`, on `v*` git tags (unchanged, no AWS involved)
+Mobile app | **TODO** — no CI yet; needs an EAS (Expo) build/submit step once App Store/Play Store credentials exist
+
+## Legacy manual deployment (anote.ai / chat.anote.ai)
+
+Tutorial reference: [How to deploy a website on AWS with Docker, Flask, React](https://adamraudonis.medium.com/how-to-deploy-a-website-on-aws-with-docker-flask-react-from-scratch-d0845ebd9da4)
+
+### Frontend — AWS S3
+
+Prod URL: `https://anote-frontend.s3.amazonaws.com/index.html`
+
+From the frontend folder:
+
+**Staging**
+```bash
+export REACT_APP_API_ENDPOINT=https://api.tryanote-staging.com
+npm run build
+aws s3 sync build/ s3://anote-staging-frontend --acl public-read
+```
+
+**Prod**
+```bash
+REACT_APP_API_ENDPOINT=https://api.anote.ai npm run build && \
+for file in ./build/static/js/*.js; do uglifyjs "$file" --compress --mangle -o "$file"; done && \
+aws s3 sync build/ s3://anote-product-frontend --acl public-read
+```
+
+Chatbot frontend bucket: `anote-chatbot-frontend`.
+
+### Documentation
+
+From `frontend/src/docs`:
+```bash
+mkdocs build
+aws s3 sync site/ s3://anote-product-docs --acl public-read
+```
+
+### Backend — AWS ECR + Elastic Beanstalk
+
+Prod EB URL: `http://anote2-env.eba-dzfpabky.us-east-1.elasticbeanstalk.com/`
+ECR URL: `730335449740.dkr.ecr.us-east-1.amazonaws.com`
+
+Local run:
+```bash
+export APP_ENV=local
+flask run
+```
+
+Make sure `requirements.txt` is up to date. From the server folder:
+```bash
+docker build -t anote-backend . --platform linux/amd64
+docker run -p 5000:5000 anote-backend   # manual smoke test against the React frontend
+# local variant: docker run -e IS_PROD=false -e APP_ENV=localdocker -p 5000:5000 anote-backend
+docker tag anote-backend:latest 730335449740.dkr.ecr.us-east-1.amazonaws.com/anote-backend:latest
+docker push 730335449740.dkr.ecr.us-east-1.amazonaws.com/anote-backend:latest
+```
+
+Staging build: `docker build -t anote-backend . --platform linux/amd64 --build-arg IS_PROD=false`
+
+If not logged into AWS/ECR:
+```bash
+aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 730335449740.dkr.ecr.us-east-1.amazonaws.com
+```
+
+Then from `server/aws_deploy` (contains `Dockerrun.aws.json`, which references
+the ECR image):
+```bash
+eb init   # select Anote2
+eb deploy
+```
+
+Specific environments:
+```bash
+eb deploy Anote2-env       # prod
+eb deploy Anotestaging-env # staging
+```
+
+### Debugging the EB instance
+
+- AWS EB console logs, or SSH: `eb ssh` (`eb ssh --setup` if not configured yet)
+- Live errors: `tail -n 20 -f /var/log/eb-docker/containers/eb-current-app/eb-88128321be16-stdouterr.log`
+- Out of disk space:
+  ```bash
+  df -H            # storage available
+  lsblk            # partitions on the machine
+  sudo growpart /dev/xvda 1
+  sudo xfs_growfs -d /
+  ```
+- Dockerfile build args: `docker build -t anote-backend . --build-arg IS_PROD=false`
+- Check a build arg's runtime value: `docker run --rm anote-backend sh -c 'echo $IS_PROD'`
+
+### Outstanding TODO (legacy track)
+
+Set up a CI/CD pipeline that runs tests before deploying, similar to
+[this Elastic Beanstalk + CodePipeline walkthrough](https://www.red-gate.com/simple-talk/blogs/deploying-a-nodejs-application-from-github-to-aws-elastic-beanstalk-and-creating-a-ci-cd-aws-codepipeline/).
+`packages/backend`'s CI (`ci.yml`) already runs ruff/mypy/pytest with an
+80% coverage gate on every push, so most of this is covered for the
+monorepo backend — what's still missing is gating the legacy `frontend/`
+and `backend/` (non-`packages/`) folders the same way, since `main.yml`
+runs their tests but nothing blocks a manual `eb deploy` on failure.

--- a/backend/aws_deploy/Dockerrun.aws.json
+++ b/backend/aws_deploy/Dockerrun.aws.json
@@ -1,0 +1,12 @@
+{
+  "AWSEBDockerrunVersion": "1",
+  "Image": {
+    "Name": "730335449740.dkr.ecr.us-east-1.amazonaws.com/anote-backend:latest",
+    "Update": "true"
+  },
+  "Ports": [
+    {
+      "ContainerPort": "5000"
+    }
+  ]
+}

--- a/docker-compose.panacea.yml
+++ b/docker-compose.panacea.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 # Runs only the Panacea backend container on the existing Private Chatbot
 # EC2 instance. Unlike docker-compose.yml (full local dev stack), this
 # assumes MySQL/Redis/Tika are already running on the instance for the

--- a/docker-compose.panacea.yml
+++ b/docker-compose.panacea.yml
@@ -1,0 +1,25 @@
+version: "3.9"
+
+# Runs only the Panacea backend container on the existing Private Chatbot
+# EC2 instance. Unlike docker-compose.yml (full local dev stack), this
+# assumes MySQL/Redis/Tika are already running on the instance for the
+# existing chatbot product and are reused via the *_HOST env vars below —
+# see terraform/panacea/README.md and DEPLOYMENT.md for the full picture.
+#
+# Lives at the repo root so `.github/workflows/deploy-panacea.yml` can SSH
+# in, `git checkout`, and run `docker compose -f docker-compose.panacea.yml
+# up -d` without any extra setup on the instance beyond a populated
+# `.env.panacea` file (gitignored, created once by hand on the instance).
+
+services:
+  backend:
+    build:
+      context: ./packages/backend
+      dockerfile: Dockerfile
+    restart: always
+    ports:
+      - "${PANACEA_BACKEND_PORT:-5000}:5000"
+    env_file:
+      - .env.panacea
+    environment:
+      APP_ENV: production

--- a/packages/desktop/forge.config.js
+++ b/packages/desktop/forge.config.js
@@ -15,7 +15,7 @@ module.exports = {
     {
       name: "@electron-forge/publisher-github",
       config: {
-        repository: { owner: "anote-ai", name: "Autonomous-Intelligence" },
+        repository: { owner: "anote-ai", name: "Panacea" },
         prerelease: false,
         draft: true,
       },

--- a/packages/docs/docs/api/chat.md
+++ b/packages/docs/docs/api/chat.md
@@ -29,6 +29,29 @@ event: done
 data: {}
 ```
 
+## Chat (non-streaming)
+
+```http
+POST /api/chat
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "message": "Explain this codebase",
+  "model": "claude-sonnet-4-6",
+  "history": [{"role": "user", "content": "earlier turn"}]
+}
+```
+
+Returns the complete response in one shot — best for scripting:
+
+```json
+{
+  "response": "This codebase...",
+  "model": "claude-sonnet-4-6"
+}
+```
+
 ## List Sessions
 
 ```http

--- a/packages/docs/docs/sdk/python.md
+++ b/packages/docs/docs/sdk/python.md
@@ -1,27 +1,56 @@
 # Python SDK
 
-A Python client is available via the `anoteai` package (part of the Anote-Product repo).
+The `anote-sdk` package (`packages/sdk-py`) provides a typed client for the
+Anote backend REST API — the same API described in [API Reference](../api/overview.md).
 
 ## Installation
 
 ```bash
-pip install anoteai
+pip install anote-sdk
 ```
 
 ## Usage
 
 ```python
-from anoteai import Anote
+from anote_sdk import AnoteClient
 
-client = Anote(api_key="your-api-key")
+client = AnoteClient(api_key="<jwt-access-token>", base_url="http://localhost:5000")
 
-# Classify text
-result = client.classify(
-    data_type="text",
-    data=["This is great!", "This is terrible."],
-    labels=["positive", "negative"],
-)
-print(result)
+# Non-streaming chat
+result = client.chat("Explain this codebase")
+print(result.response)
+
+# Streaming chat
+for chunk in client.chat_stream("Explain this codebase"):
+    print(chunk, end="", flush=True)
+
+# Codebase search (TF-IDF, requires `anote index` to have run first)
+search = client.search("authentication logic")
+for hit in search.results:
+    print(hit.file, hit.start_line, hit.score)
 ```
 
-See the [Anote-Product repository](https://github.com/anote-ai/anote-product) for full SDK documentation.
+An async client is also available:
+
+```python
+from anote_sdk import AsyncAnoteClient
+
+async with AsyncAnoteClient(api_key="<jwt-access-token>") as client:
+    result = await client.chat("Explain this codebase")
+    print(result.response)
+```
+
+## API Reference
+
+| Method | Description |
+|--------|-------------|
+| `chat(message, model=..., history=...)` | Send a message, get a complete response |
+| `chat_stream(message, model=..., cwd=...)` | Send a message, yield response text chunks over SSE |
+| `create_session()` | Create a new chat session, returns its ID |
+| `list_sessions()` | List all chat session IDs |
+| `get_session_messages(session_id)` | Get a session's message history |
+| `delete_session(session_id)` | Delete a session |
+| `search(query, cwd=..., top=...)` | TF-IDF search over the codebase index |
+| `health()` | Health check (no auth required) |
+
+See [`packages/sdk-py`](https://github.com/anote-ai/Panacea/tree/main/packages/sdk-py) for source and tests.

--- a/packages/docs/docs/sdk/typescript.md
+++ b/packages/docs/docs/sdk/typescript.md
@@ -1,6 +1,7 @@
 # TypeScript SDK
 
-The `@anote-ai/sdk` package provides a typed client for the Anote backend API.
+The `@anote-ai/sdk` package provides a typed client for the Anote backend
+REST API — the same API described in [API Reference](../api/overview.md).
 
 ## Installation
 
@@ -11,21 +12,24 @@ npm install @anote-ai/sdk
 ## Usage
 
 ```typescript
-import AnoteClient from '@anote-ai/sdk';
+import { AnoteClient } from '@anote-ai/sdk';
 
 const client = new AnoteClient({
-  baseUrl: 'https://api.anote.ai',
-  apiKey: 'your-api-key',
+  baseUrl: 'http://localhost:5000',
+  apiKey: '<jwt-access-token>',
 });
 
-// Chat
-const response = await client.chat({
-  message: 'Explain this codebase',
-  model: 'claude-sonnet-4-6',
-});
+// Non-streaming chat
+const { response } = await client.chat('Explain this codebase');
+console.log(response);
 
-// Search
-const results = await client.search({ query: 'authentication logic', cwd: '.' });
+// Streaming chat
+for await (const chunk of client.chatStream('Explain this codebase')) {
+  process.stdout.write(chunk);
+}
+
+// Codebase search (TF-IDF, requires `anote index` to have run first)
+const { results } = await client.search('authentication logic');
 
 // Health check
 const health = await client.health();
@@ -35,10 +39,11 @@ const health = await client.health();
 
 | Method | Description |
 |--------|-------------|
-| `chat(options)` | Send a chat message |
-| `listSessions()` | List chat sessions |
-| `getSessionMessages(id)` | Get messages in a session |
+| `chat(message, options)` | Send a message, get a complete response |
+| `chatStream(message, options)` | Send a message, yield response text chunks over SSE |
+| `createSession()` | Create a new chat session, returns its ID |
+| `listSessions()` | List all chat session IDs |
+| `getSessionMessages(id)` | Get a session's message history |
 | `deleteSession(id)` | Delete a session |
-| `search(options)` | Search the codebase index |
-| `getUsage()` | Get API usage stats |
-| `health()` | Health check |
+| `search(query, options)` | TF-IDF search over the codebase index |
+| `health()` | Health check (no auth required) |

--- a/packages/sdk-py/README.md
+++ b/packages/sdk-py/README.md
@@ -1,0 +1,44 @@
+# anote-sdk
+
+Python SDK for the Anote AI assistant REST API.
+
+## Installation
+
+```bash
+pip install anote-sdk
+```
+
+## Usage
+
+```python
+from anote_sdk import AnoteClient
+
+client = AnoteClient(api_key="<jwt-access-token>", base_url="http://localhost:5000")
+
+result = client.chat("Explain this codebase")
+print(result.response)
+
+for chunk in client.chat_stream("Explain this codebase"):
+    print(chunk, end="", flush=True)
+
+search = client.search("authentication logic")
+for hit in search.results:
+    print(hit.file, hit.start_line, hit.score)
+```
+
+An async client is also available:
+
+```python
+from anote_sdk import AsyncAnoteClient
+
+async with AsyncAnoteClient(api_key="<jwt-access-token>") as client:
+    result = await client.chat("Explain this codebase")
+    print(result.response)
+```
+
+## Development
+
+```bash
+pip install -e ".[dev]"
+pytest
+```

--- a/packages/sdk-py/anote_sdk/__init__.py
+++ b/packages/sdk-py/anote_sdk/__init__.py
@@ -5,34 +5,31 @@ Example::
 
     from anote_sdk import AnoteClient
 
-    client = AnoteClient(api_key="ant-...", base_url="http://localhost:5000")
+    client = AnoteClient(api_key="<jwt-access-token>", base_url="http://localhost:5000")
 
     result = client.chat("Explain this codebase")
-    print(result.result)
+    print(result.response)
 """
 
-from .client import AnoteClient, AnoteError
+from .client import AnoteClient, AsyncAnoteClient, AnoteError
 from .models import (
+    ChatMessage,
     ChatResult,
-    SessionSummary,
-    Message,
+    SessionMessages,
     SearchResult,
-    UsageSummary,
-    MonthlyUsage,
-    UsageQuota,
-    ShareResult,
+    SearchResponse,
+    HealthResult,
 )
 
 __all__ = [
     "AnoteClient",
+    "AsyncAnoteClient",
     "AnoteError",
+    "ChatMessage",
     "ChatResult",
-    "SessionSummary",
-    "Message",
+    "SessionMessages",
     "SearchResult",
-    "UsageSummary",
-    "MonthlyUsage",
-    "UsageQuota",
-    "ShareResult",
+    "SearchResponse",
+    "HealthResult",
 ]
 __version__ = "1.0.0"

--- a/packages/sdk-py/anote_sdk/client.py
+++ b/packages/sdk-py/anote_sdk/client.py
@@ -2,16 +2,15 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, AsyncGenerator, Generator, Optional
+import json
 import httpx
 
 from .models import (
+    ChatMessage,
     ChatResult,
-    SessionSummary,
-    Message,
-    SearchResult,
-    UsageSummary,
-    ShareResult,
+    SessionMessages,
+    SearchResponse,
     HealthResult,
 )
 
@@ -37,6 +36,21 @@ def _raise_for_status(response: httpx.Response) -> dict:
     return data
 
 
+def _parse_sse_events(raw: str) -> Generator[tuple[str, dict], None, None]:
+    for event in raw.split("\n\n"):
+        if not event.strip():
+            continue
+        event_type = "text"
+        data = None
+        for line in event.split("\n"):
+            if line.startswith("event: "):
+                event_type = line[len("event: "):]
+            elif line.startswith("data: "):
+                data = json.loads(line[len("data: "):])
+        if data is not None:
+            yield event_type, data
+
+
 _DEFAULT_BASE = "https://api.anote.ai"
 _USER_AGENT = "anote-sdk-python/1.0.0"
 
@@ -45,7 +59,7 @@ class AnoteClient:
     """Synchronous Anote API client.
 
     Args:
-        api_key: Your Anote API key.
+        api_key: Bearer token (JWT access token from ``/auth/login``).
         base_url: Server base URL. Defaults to ``https://api.anote.ai``.
         timeout: Request timeout in seconds. Defaults to 60.
     """
@@ -58,7 +72,7 @@ class AnoteClient:
     ) -> None:
         if not api_key:
             raise ValueError("api_key is required")
-        self._base = base_url.rstrip("/") + "/api/v1"
+        self._base = base_url.rstrip("/")
         self._headers = {
             "Authorization": f"Bearer {api_key}",
             "User-Agent": _USER_AGENT,
@@ -84,45 +98,72 @@ class AnoteClient:
         self,
         message: str,
         *,
-        cwd: Optional[str] = None,
         model: str = "claude-sonnet-4-6",
-        tools: Optional[list[str]] = None,
+        history: Optional[list[ChatMessage]] = None,
     ) -> ChatResult:
-        """Send a message and receive a complete AI response."""
+        """Send a message and receive a complete (non-streaming) AI response."""
+        payload: dict = {"message": message, "model": model}
+        if history:
+            payload["history"] = [h.model_dump(by_alias=True) for h in history]
+        return ChatResult.model_validate(self._post("/api/chat", payload))
+
+    def chat_stream(
+        self,
+        message: str,
+        *,
+        model: str = "claude-sonnet-4-6",
+        cwd: Optional[str] = None,
+    ) -> Generator[str, None, None]:
+        """Send a message and yield text chunks as they're generated over SSE."""
         payload: dict = {"message": message, "model": model}
         if cwd:
             payload["cwd"] = cwd
-        if tools:
-            payload["tools"] = tools
-        return ChatResult.model_validate(self._post("/chat", payload))
+        with httpx.Client(timeout=self._timeout) as http:
+            with http.stream(
+                "POST", f"{self._base}/api/chat/stream", headers=self._headers, json=payload
+            ) as r:
+                if r.is_error:
+                    r.read()
+                    _raise_for_status(r)
+                buffer = ""
+                for chunk in r.iter_text():
+                    buffer += chunk
+                    while "\n\n" in buffer:
+                        event, buffer = buffer.split("\n\n", 1)
+                        for event_type, data in _parse_sse_events(event + "\n\n"):
+                            if event_type == "text" and data.get("text"):
+                                yield data["text"]
+                            elif event_type == "error":
+                                raise AnoteError(data.get("message", "stream error"), 0, data)
 
-    def list_sessions(self) -> list[SessionSummary]:
-        """List all chat sessions."""
-        data = self._get("/sessions")
-        return [SessionSummary.model_validate(s) for s in data]
+    # ── Sessions ──────────────────────────────────────────────────────────────
+    # Note: sessions are currently just server-side placeholders — creating
+    # one doesn't yet link it to chat()/chat_stream() calls.
 
-    def get_session_messages(self, session_id: str) -> list[Message]:
-        """Get full message history for a session."""
-        data = self._get(f"/sessions/{session_id}/messages")
-        return [Message.model_validate(m) for m in data.get("history", [])]
+    def create_session(self) -> str:
+        """Create a new (empty) chat session. Returns the new session ID."""
+        return self._post("/api/chat/sessions")["sessionId"]
+
+    def list_sessions(self) -> list[str]:
+        """List all chat session IDs on the server."""
+        return self._get("/api/chat/sessions").get("sessions", [])
+
+    def get_session_messages(self, session_id: str) -> SessionMessages:
+        """Get the message history of a session."""
+        return SessionMessages.model_validate(self._get(f"/api/chat/sessions/{session_id}"))
 
     def delete_session(self, session_id: str) -> bool:
         """Delete a session. Returns True on success."""
-        data = self._delete(f"/sessions/{session_id}")
-        return bool(data.get("ok"))
+        return bool(self._delete(f"/api/chat/sessions/{session_id}").get("deleted"))
 
-    def share_session(self, session_id: str) -> ShareResult:
-        """Mint a shareable read-only link for a session."""
-        return ShareResult.model_validate(self._post(f"/sessions/{session_id}/share"))
+    # ── Search ────────────────────────────────────────────────────────────────
 
-    def search(self, query: str, limit: int = 20) -> list[SearchResult]:
-        """Full-text search across all session histories."""
-        data = self._get("/search", params={"q": query, "limit": limit})
-        return [SearchResult.model_validate(r) for r in data.get("results", [])]
-
-    def get_usage(self) -> UsageSummary:
-        """Get current month usage and remaining quota."""
-        return UsageSummary.model_validate(self._get("/usage"))
+    def search(self, query: str, cwd: Optional[str] = None, top: int = 10) -> SearchResponse:
+        """TF-IDF search over the codebase index built by `anote index`."""
+        params: dict = {"q": query, "top": top}
+        if cwd:
+            params["cwd"] = cwd
+        return SearchResponse.model_validate(self._get("/api/search", params=params))
 
     def health(self) -> HealthResult:
         """Check server liveness. Does not require authentication."""
@@ -142,7 +183,7 @@ class AsyncAnoteClient:
     ) -> None:
         if not api_key:
             raise ValueError("api_key is required")
-        self._base = base_url.rstrip("/") + "/api/v1"
+        self._base = base_url.rstrip("/")
         self._headers = {
             "Authorization": f"Bearer {api_key}",
             "User-Agent": _USER_AGENT,
@@ -175,33 +216,62 @@ class AsyncAnoteClient:
         r = await self._client().delete(f"{self._base}{path}", headers=self._headers)
         return _raise_for_status(r)
 
-    async def chat(self, message: str, *, cwd: Optional[str] = None, model: str = "claude-sonnet-4-6", tools: Optional[list[str]] = None) -> ChatResult:
+    async def chat(
+        self,
+        message: str,
+        *,
+        model: str = "claude-sonnet-4-6",
+        history: Optional[list[ChatMessage]] = None,
+    ) -> ChatResult:
+        payload: dict = {"message": message, "model": model}
+        if history:
+            payload["history"] = [h.model_dump(by_alias=True) for h in history]
+        return ChatResult.model_validate(await self._post("/api/chat", payload))
+
+    async def chat_stream(
+        self,
+        message: str,
+        *,
+        model: str = "claude-sonnet-4-6",
+        cwd: Optional[str] = None,
+    ) -> AsyncGenerator[str, None]:
         payload: dict = {"message": message, "model": model}
         if cwd:
             payload["cwd"] = cwd
-        if tools:
-            payload["tools"] = tools
-        return ChatResult.model_validate(await self._post("/chat", payload))
+        async with self._client().stream(
+            "POST", f"{self._base}/api/chat/stream", headers=self._headers, json=payload
+        ) as r:
+            if r.is_error:
+                await r.aread()
+                _raise_for_status(r)
+            buffer = ""
+            async for chunk in r.aiter_text():
+                buffer += chunk
+                while "\n\n" in buffer:
+                    event, buffer = buffer.split("\n\n", 1)
+                    for event_type, data in _parse_sse_events(event + "\n\n"):
+                        if event_type == "text" and data.get("text"):
+                            yield data["text"]
+                        elif event_type == "error":
+                            raise AnoteError(data.get("message", "stream error"), 0, data)
 
-    async def list_sessions(self) -> list[SessionSummary]:
-        return [SessionSummary.model_validate(s) for s in await self._get("/sessions")]
+    async def create_session(self) -> str:
+        return (await self._post("/api/chat/sessions"))["sessionId"]
 
-    async def get_session_messages(self, session_id: str) -> list[Message]:
-        data = await self._get(f"/sessions/{session_id}/messages")
-        return [Message.model_validate(m) for m in data.get("history", [])]
+    async def list_sessions(self) -> list[str]:
+        return (await self._get("/api/chat/sessions")).get("sessions", [])
+
+    async def get_session_messages(self, session_id: str) -> SessionMessages:
+        return SessionMessages.model_validate(await self._get(f"/api/chat/sessions/{session_id}"))
 
     async def delete_session(self, session_id: str) -> bool:
-        return bool((await self._delete(f"/sessions/{session_id}")).get("ok"))
+        return bool((await self._delete(f"/api/chat/sessions/{session_id}")).get("deleted"))
 
-    async def share_session(self, session_id: str) -> ShareResult:
-        return ShareResult.model_validate(await self._post(f"/sessions/{session_id}/share"))
-
-    async def search(self, query: str, limit: int = 20) -> list[SearchResult]:
-        data = await self._get("/search", params={"q": query, "limit": limit})
-        return [SearchResult.model_validate(r) for r in data.get("results", [])]
-
-    async def get_usage(self) -> UsageSummary:
-        return UsageSummary.model_validate(await self._get("/usage"))
+    async def search(self, query: str, cwd: Optional[str] = None, top: int = 10) -> SearchResponse:
+        params: dict = {"q": query, "top": top}
+        if cwd:
+            params["cwd"] = cwd
+        return SearchResponse.model_validate(await self._get("/api/search", params=params))
 
     async def health(self) -> HealthResult:
         r = await self._client().get(f"{self._base}/health", headers={"User-Agent": _USER_AGENT})

--- a/packages/sdk-py/anote_sdk/models.py
+++ b/packages/sdk-py/anote_sdk/models.py
@@ -1,7 +1,7 @@
 """Pydantic v2 models for Anote API responses (camelCase JSON → snake_case Python)."""
 
 from __future__ import annotations
-from typing import Literal, Union
+from typing import Literal
 from pydantic import BaseModel, ConfigDict
 
 
@@ -14,73 +14,35 @@ class _Base(BaseModel):
     model_config = ConfigDict(populate_by_name=True, alias_generator=_camel)
 
 
-class TokenUsage(_Base):
-    input_tokens: int = 0
-    output_tokens: int = 0
+class ChatMessage(_Base):
+    role: Literal["user", "assistant"]
+    content: str
 
 
 class ChatResult(_Base):
-    result: str
-    usage: TokenUsage
+    response: str
+    model: str
 
 
-class SessionSummary(_Base):
+class SessionMessages(_Base):
     session_id: str
-    cwd: str = ""
-    message_count: int = 0
-    input_tokens: int = 0
-    output_tokens: int = 0
-    model: str = ""
-    created_at: int = 0
-    updated_at: int = 0
-
-
-class Message(_Base):
-    role: Literal["user", "assistant"]
-    content: str
-    ts: int = 0
+    messages: list[ChatMessage] = []
 
 
 class SearchResult(_Base):
-    session_id: str = ""
-    role: str = ""
-    snippet: str = ""
-    ts: int = 0
+    file: str = ""
+    start_line: int = 0
+    end_line: int = 0
+    preview: str = ""
+    score: float = 0.0
 
 
-class MonthlyUsage(_Base):
-    month: str = ""
-    request_count: int = 0
-    input_tokens: int = 0
-    output_tokens: int = 0
-    updated_at: int = 0
-
-
-class UsageQuota(_Base):
-    plan: Literal["free", "pro"] = "free"
-    max_requests: int = 0
-    max_input_tokens: int = 0
-    max_output_tokens: int = 0
-
-
-class UsageRemaining(_Base):
-    requests: Union[int, Literal["unlimited"]] = 0
-    input_tokens: Union[int, Literal["unlimited"]] = 0
-    output_tokens: Union[int, Literal["unlimited"]] = 0
-
-
-class UsageSummary(_Base):
-    current: MonthlyUsage = MonthlyUsage()
-    quota: UsageQuota = UsageQuota()
-    remaining: UsageRemaining = UsageRemaining()
-    history: list[MonthlyUsage] = []
-
-
-class ShareResult(_Base):
-    token: str = ""
-    share_url: str = ""
+class SearchResponse(_Base):
+    results: list[SearchResult] = []
+    query: str = ""
+    cwd: str = ""
 
 
 class HealthResult(_Base):
     status: str = "ok"
-    version: str = ""
+    service: str = ""

--- a/packages/sdk-py/pyproject.toml
+++ b/packages/sdk-py/pyproject.toml
@@ -23,8 +23,8 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/anote-ai/Autonomous-Intelligence"
-Repository = "https://github.com/anote-ai/Autonomous-Intelligence"
+Homepage = "https://github.com/anote-ai/Panacea"
+Repository = "https://github.com/anote-ai/Panacea"
 
 [tool.hatch.build.targets.wheel]
 packages = ["anote_sdk"]

--- a/packages/sdk-py/tests/test_client.py
+++ b/packages/sdk-py/tests/test_client.py
@@ -6,7 +6,7 @@ import respx
 import httpx
 
 from anote_sdk import AnoteClient, AnoteError
-from anote_sdk.models import ChatResult, HealthResult
+from anote_sdk.models import ChatResult
 
 
 BASE = "http://localhost:5000"
@@ -14,7 +14,7 @@ BASE = "http://localhost:5000"
 
 @pytest.fixture
 def client():
-    return AnoteClient(api_key="ant-test", base_url=BASE)
+    return AnoteClient(api_key="test-token", base_url=BASE)
 
 
 def test_constructor_requires_api_key():
@@ -24,42 +24,44 @@ def test_constructor_requires_api_key():
 
 def test_health(client):
     with respx.mock:
-        respx.get(f"{BASE}/api/v1/health").mock(
-            return_value=httpx.Response(200, json={"status": "ok", "version": "1.0.0"})
+        respx.get(f"{BASE}/health").mock(
+            return_value=httpx.Response(200, json={"status": "ok", "service": "anote-backend"})
         )
         result = client.health()
     assert result.status == "ok"
+    assert result.service == "anote-backend"
 
 
 def test_chat(client):
     with respx.mock:
-        respx.post(f"{BASE}/api/v1/chat").mock(
+        respx.post(f"{BASE}/api/chat").mock(
             return_value=httpx.Response(200, json={
-                "result": "Hello world",
-                "usage": {"inputTokens": 10, "outputTokens": 5},
+                "response": "Hello world",
+                "model": "claude-sonnet-4-6",
             })
         )
         result = client.chat("say hello")
-    assert result.result == "Hello world"
+    assert result.response == "Hello world"
     assert isinstance(result, ChatResult)
 
 
-def test_chat_with_cwd_and_tools(client):
+def test_chat_with_history(client):
     with respx.mock:
-        route = respx.post(f"{BASE}/api/v1/chat").mock(
-            return_value=httpx.Response(200, json={
-                "result": "done",
-                "usage": {"inputTokens": 1, "outputTokens": 1},
-            })
+        route = respx.post(f"{BASE}/api/chat").mock(
+            return_value=httpx.Response(200, json={"response": "done", "model": "claude-sonnet-4-6"})
         )
-        result = client.chat("fix bug", cwd="/project", tools=["bash"])
-    assert result.result == "done"
+        from anote_sdk.models import ChatMessage
+
+        result = client.chat("fix bug", history=[ChatMessage(role="user", content="earlier turn")])
+    assert result.response == "done"
     assert route.called
+    sent_body = route.calls[0].request.content
+    assert b"earlier turn" in sent_body
 
 
 def test_error_raises_anote_error(client):
     with respx.mock:
-        respx.post(f"{BASE}/api/v1/chat").mock(
+        respx.post(f"{BASE}/api/chat").mock(
             return_value=httpx.Response(401, json={"error": "Unauthorized"})
         )
         with pytest.raises(AnoteError) as exc_info:
@@ -69,17 +71,39 @@ def test_error_raises_anote_error(client):
 
 def test_list_sessions_empty(client):
     with respx.mock:
-        respx.get(f"{BASE}/api/v1/sessions").mock(
-            return_value=httpx.Response(200, json=[])
+        respx.get(f"{BASE}/api/chat/sessions").mock(
+            return_value=httpx.Response(200, json={"sessions": []})
         )
         sessions = client.list_sessions()
     assert sessions == []
 
 
+def test_create_session(client):
+    with respx.mock:
+        respx.post(f"{BASE}/api/chat/sessions").mock(
+            return_value=httpx.Response(201, json={"sessionId": "abc123"})
+        )
+        session_id = client.create_session()
+    assert session_id == "abc123"
+
+
+def test_get_session_messages(client):
+    with respx.mock:
+        respx.get(f"{BASE}/api/chat/sessions/abc123").mock(
+            return_value=httpx.Response(
+                200,
+                json={"sessionId": "abc123", "messages": [{"role": "user", "content": "hi"}]},
+            )
+        )
+        session = client.get_session_messages("abc123")
+    assert session.session_id == "abc123"
+    assert session.messages[0].content == "hi"
+
+
 def test_delete_session(client):
     with respx.mock:
-        respx.delete(f"{BASE}/api/v1/sessions/abc123").mock(
-            return_value=httpx.Response(200, json={"ok": True})
+        respx.delete(f"{BASE}/api/chat/sessions/abc123").mock(
+            return_value=httpx.Response(200, json={"deleted": True})
         )
         ok = client.delete_session("abc123")
     assert ok is True
@@ -87,8 +111,19 @@ def test_delete_session(client):
 
 def test_search(client):
     with respx.mock:
-        respx.get(f"{BASE}/api/v1/search").mock(
-            return_value=httpx.Response(200, json={"results": []})
+        respx.get(f"{BASE}/api/search").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "results": [
+                        {"file": "app.py", "startLine": 1, "endLine": 5, "preview": "...", "score": 0.9}
+                    ],
+                    "query": "hello",
+                    "cwd": "/project",
+                },
+            )
         )
-        results = client.search("hello")
-    assert results == []
+        response = client.search("hello")
+    assert response.query == "hello"
+    assert response.results[0].file == "app.py"
+    assert response.results[0].start_line == 1

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { AnoteClient } from "./index.js";
 
 describe("AnoteClient", () => {
@@ -10,5 +10,67 @@ describe("AnoteClient", () => {
   it("constructs with default base URL", () => {
     const client = new AnoteClient({ apiKey: "test-key" });
     expect(client).toBeDefined();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("chat() posts to /api/chat with no version prefix", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ response: "hi", model: "claude-sonnet-4-6" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new AnoteClient({ apiKey: "test-key", baseUrl: "http://localhost:5000" });
+    const result = await client.chat("hello");
+
+    expect(result).toEqual({ response: "hi", model: "claude-sonnet-4-6" });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://localhost:5000/api/chat");
+    expect(JSON.parse(init.body)).toEqual({ message: "hello", model: undefined, history: undefined });
+  });
+
+  it("listSessions() unwraps the { sessions } envelope", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ sessions: ["a", "b"] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new AnoteClient({ apiKey: "test-key", baseUrl: "http://localhost:5000" });
+    const sessions = await client.listSessions();
+
+    expect(sessions).toEqual(["a", "b"]);
+    expect(fetchMock.mock.calls[0][0]).toBe("http://localhost:5000/api/chat/sessions");
+  });
+
+  it("deleteSession() unwraps the { deleted } envelope", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ deleted: true }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new AnoteClient({ apiKey: "test-key", baseUrl: "http://localhost:5000" });
+    const deleted = await client.deleteSession("abc");
+
+    expect(deleted).toBe(true);
+    expect(fetchMock.mock.calls[0][0]).toBe("http://localhost:5000/api/chat/sessions/abc");
+  });
+
+  it("health() hits /health with no /api prefix", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ status: "ok", service: "anote-backend" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new AnoteClient({ apiKey: "test-key", baseUrl: "http://localhost:5000" });
+    const health = await client.health();
+
+    expect(health).toEqual({ status: "ok", service: "anote-backend" });
+    expect(fetchMock.mock.calls[0][0]).toBe("http://localhost:5000/health");
   });
 });

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,96 +1,75 @@
 /**
- * @anote-ai/sdk — TypeScript SDK for the Anote REST API v1.
+ * @anote-ai/sdk — TypeScript SDK for the Anote backend REST API.
  *
  * @example
  * ```ts
  * import { AnoteClient } from "@anote-ai/sdk";
  *
- * const client = new AnoteClient({ apiKey: "ant-..." });
+ * const client = new AnoteClient({ apiKey: "<jwt-access-token>" });
  *
- * const { result } = await client.chat("Explain this codebase");
- * console.log(result);
+ * const { response } = await client.chat("Explain this codebase");
+ * console.log(response);
  *
- * const usage = await client.getUsage();
- * console.log(`Used ${usage.current.requestCount} requests this month`);
+ * for await (const chunk of client.chatStream("Explain this codebase")) {
+ *   process.stdout.write(chunk);
+ * }
  * ```
  */
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 export interface AnoteClientOptions {
-  /** API key starting with `ant-`. Generate one at your Anote instance → Settings → API Keys. */
+  /** Bearer token (JWT access token from /auth/login) sent as `Authorization: Bearer <token>`. */
   apiKey: string;
   /** Base URL of your Anote server. Defaults to `https://api.anote.ai`. */
   baseUrl?: string;
 }
 
+export interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
 export interface ChatOptions {
-  /** Working directory for file operations on the server. */
-  cwd?: string;
-  /** Claude model to use. */
-  model?: "claude-opus-4-6" | "claude-sonnet-4-6" | "claude-haiku-4-5";
-  /** Tools the AI may use. Default: read-only tools. */
-  tools?: ("Read" | "Write" | "Edit" | "Bash" | "Glob" | "Grep")[];
+  /** Claude model to use. Defaults to the server's default model. */
+  model?: string;
+  /** Prior turns to include as conversation context. */
+  history?: ChatMessage[];
 }
 
 export interface ChatResult {
-  result: string;
-  usage: { inputTokens: number; outputTokens: number };
-}
-
-export interface SessionSummary {
-  sessionId: string;
-  cwd: string;
-  messageCount: number;
-  inputTokens: number;
-  outputTokens: number;
+  response: string;
   model: string;
-  createdAt: number;
-  updatedAt: number;
 }
 
-export interface Message {
-  role: "user" | "assistant";
-  content: string;
-  ts: number;
+export interface ChatStreamOptions {
+  model?: string;
+  /** Working directory for file operations on the server. Defaults to the server's cwd. */
+  cwd?: string;
+}
+
+export interface SessionMessages {
+  sessionId: string;
+  messages: ChatMessage[];
 }
 
 export interface SearchResult {
-  sessionId: string;
-  role: string;
-  snippet: string;
-  ts: number;
+  file: string;
+  startLine: number;
+  endLine: number;
+  preview: string;
+  score: number;
 }
 
-export interface MonthlyUsage {
-  month: string;
-  requestCount: number;
-  inputTokens: number;
-  outputTokens: number;
-  updatedAt: number;
+export interface SearchResponse {
+  results: SearchResult[];
+  query: string;
+  cwd: string;
 }
 
-export interface UsageQuota {
-  plan: "free" | "pro";
-  maxRequests: number;
-  maxInputTokens: number;
-  maxOutputTokens: number;
-}
-
-export interface UsageSummary {
-  current: MonthlyUsage;
-  quota: UsageQuota;
-  remaining: {
-    requests: number | "unlimited";
-    inputTokens: number | "unlimited";
-    outputTokens: number | "unlimited";
-  };
-  history: MonthlyUsage[];
-}
-
-export interface ShareResult {
-  token: string;
-  shareUrl: string;
+export interface HealthResult {
+  status: string;
+  service: string;
 }
 
 // ── Error class ─────────────────────────────────────────────────────────────────────
@@ -115,7 +94,7 @@ export class AnoteClient {
   constructor(options: AnoteClientOptions) {
     if (!options.apiKey) throw new Error("apiKey is required");
     this.apiKey = options.apiKey;
-    this.baseUrl = (options.baseUrl ?? "https://api.anote.ai").replace(/\/$/, "") + "/api/v1";
+    this.baseUrl = (options.baseUrl ?? "https://api.anote.ai").replace(/\/$/, "");
   }
 
   // ── Core HTTP ───────────────────────────────────────────────────────────────────
@@ -124,7 +103,7 @@ export class AnoteClient {
     method: string,
     path: string,
     body?: unknown,
-    params?: Record<string, string | number>,
+    params?: Record<string, string | number | undefined>,
   ): Promise<T> {
     let url = `${this.baseUrl}${path}`;
     if (params) {
@@ -158,59 +137,106 @@ export class AnoteClient {
 
   // ── Chat ────────────────────────────────────────────────────────────────────────
 
-  /**
-   * Send a message to the AI and receive a complete response.
-   * Uses the non-streaming endpoint — best for scripting and automation.
-   */
+  /** Send a message and receive a complete (non-streaming) AI response. */
   async chat(message: string, options: ChatOptions = {}): Promise<ChatResult> {
-    return this.request<ChatResult>("POST", "/chat", {
+    return this.request<ChatResult>("POST", "/api/chat", {
       message,
-      cwd:   options.cwd,
       model: options.model,
-      tools: options.tools,
+      history: options.history,
     });
   }
 
+  /**
+   * Send a message and stream the response as it's generated, yielding text
+   * chunks as they arrive over Server-Sent Events.
+   */
+  async *chatStream(message: string, options: ChatStreamOptions = {}): AsyncGenerator<string> {
+    const res = await fetch(`${this.baseUrl}/api/chat/stream`, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${this.apiKey}`,
+        "Content-Type": "application/json",
+        "User-Agent": "@anote-ai/sdk/1.0.0",
+      },
+      body: JSON.stringify({ message, model: options.model, cwd: options.cwd }),
+    });
+
+    if (!res.ok || !res.body) {
+      const data = await res.json().catch(() => ({}));
+      const msg = (data as { error?: string }).error ?? `HTTP ${res.status}`;
+      throw new AnoteError(msg, res.status, data);
+    }
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      const events = buffer.split("\n\n");
+      buffer = events.pop() ?? "";
+
+      for (const event of events) {
+        const dataLine = event.split("\n").find((line) => line.startsWith("data: "));
+        const eventLine = event.split("\n").find((line) => line.startsWith("event: "));
+        if (!dataLine) continue;
+
+        const eventType = eventLine?.slice("event: ".length) ?? "text";
+        const payload = JSON.parse(dataLine.slice("data: ".length));
+
+        if (eventType === "text" && payload.text) yield payload.text as string;
+        if (eventType === "error") throw new AnoteError(payload.message ?? "stream error", 0, payload);
+      }
+    }
+  }
+
   // ── Sessions ─────────────────────────────────────────────────────────────────────────
+  // Note: sessions are currently just server-side placeholders — creating one
+  // doesn't yet link it to chat()/chatStream() calls.
 
-  /** List all chat sessions on the server. */
-  async listSessions(): Promise<SessionSummary[]> {
-    return this.request<SessionSummary[]>("GET", "/sessions");
+  /** Create a new (empty) chat session. */
+  async createSession(): Promise<{ sessionId: string }> {
+    return this.request("POST", "/api/chat/sessions");
   }
 
-  /** Get the full message history of a session. */
-  async getSessionMessages(sessionId: string): Promise<{ sessionId: string; history: Message[] }> {
-    return this.request("GET", `/sessions/${encodeURIComponent(sessionId)}/messages`);
+  /** List all chat session IDs on the server. */
+  async listSessions(): Promise<string[]> {
+    const data = await this.request<{ sessions: string[] }>("GET", "/api/chat/sessions");
+    return data.sessions;
   }
 
-  /** Delete a session. */
-  async deleteSession(sessionId: string): Promise<{ ok: boolean }> {
-    return this.request("DELETE", `/sessions/${encodeURIComponent(sessionId)}`);
+  /** Get the message history of a session. */
+  async getSessionMessages(sessionId: string): Promise<SessionMessages> {
+    return this.request("GET", `/api/chat/sessions/${encodeURIComponent(sessionId)}`);
   }
 
-  /** Mint a shareable read-only link for a session. */
-  async shareSession(sessionId: string): Promise<ShareResult> {
-    return this.request("POST", `/sessions/${encodeURIComponent(sessionId)}/share`);
+  /** Delete a session. Returns true on success. */
+  async deleteSession(sessionId: string): Promise<boolean> {
+    const data = await this.request<{ deleted: boolean }>(
+      "DELETE",
+      `/api/chat/sessions/${encodeURIComponent(sessionId)}`,
+    );
+    return data.deleted;
   }
 
   // ── Search ──────────────────────────────────────────────────────────────────────────
 
-  /** Full-text search across all session histories. */
-  async search(query: string, limit = 20): Promise<{ q: string; results: SearchResult[] }> {
-    return this.request("GET", "/search", undefined, { q: query, limit });
-  }
-
-  // ── Usage & billing ──────────────────────────────────────────────────────────────────────
-
-  /** Get current month usage and remaining quota. */
-  async getUsage(): Promise<UsageSummary> {
-    return this.request<UsageSummary>("GET", "/usage");
+  /** TF-IDF search over the codebase index built by `anote index`. */
+  async search(query: string, options: { cwd?: string; top?: number } = {}): Promise<SearchResponse> {
+    return this.request("GET", "/api/search", undefined, {
+      q: query,
+      cwd: options.cwd,
+      top: options.top,
+    });
   }
 
   // ── Health ─────────────────────────────────────────────────────────────────────────────
 
   /** Check server liveness. Does not require authentication. */
-  async health(): Promise<{ status: string; version: string }> {
+  async health(): Promise<HealthResult> {
     const res = await fetch(`${this.baseUrl}/health`, {
       headers: { "User-Agent": "@anote-ai/sdk/1.0.0" },
     });

--- a/terraform/panacea/README.md
+++ b/terraform/panacea/README.md
@@ -1,0 +1,95 @@
+# Terraform — Panacea deployment
+
+Provisions the AWS pieces for Panacea (the developer-facing assistant:
+web app, VS Code extension, CLI, desktop app, mobile app, cookbook/docs)
+**without** standing up new compute. This stack deliberately reuses the
+existing Private Chatbot EC2 instance for the backend instead of the
+ECS/Fargate/RDS setup in `../` (the original anote-ai stack), so the whole
+thing stays inside the ≤$100/month budget target:
+
+| Resource                              | Rough monthly cost |
+|----------------------------------------|---------------------|
+| EC2 instance                          | $0 marginal — already running/paid for |
+| S3 (web + cookbook buckets)           | ~$1–2 at low traffic |
+| CloudFront (2 distributions)          | ~$5–15 at low-to-moderate traffic |
+| Route 53 hosted zone                  | $0.50/mo + $0.40/million queries |
+| ACM certificate                       | free |
+| **Total**                              | **well under $100/month** |
+
+It provisions:
+
+- An **S3 + CloudFront** distribution for the web app (`packages/web`),
+  with `/api/*`, `/auth/*`, `/health` routed to the existing EC2 instance so
+  the SPA can keep using same-origin relative paths, same pattern as `../cloudfront.tf`.
+- A second **S3 + CloudFront** distribution for the developer cookbook/docs
+  site (`packages/docs`, built with MkDocs), served from `cookbook.<domain>`.
+- An **ACM certificate** (us-east-1, DNS-validated) covering the apex domain
+  and the cookbook subdomain.
+- Either a **Route 53 hosted zone** (if `manage_route53_zone = true`, the
+  default) or nothing (if `false`, GoDaddy stays authoritative for DNS —
+  see below).
+- A **security group rule** opening the backend port on the *existing*
+  instance's security group so CloudFront can reach it. Nothing about the
+  instance itself is created or replaced — it's looked up via
+  `data "aws_instance"` by its `Name` tag (`var.ec2_instance_name_tag`).
+
+## One-time setup
+
+1. Create/reuse an S3 bucket for Terraform state and configure the
+   `backend "s3"` block in `versions.tf` with a **key distinct from the
+   main anote-ai stack** (e.g. `panacea/terraform.tfstate`), then
+   `terraform init`.
+2. Set the required variables (via `terraform.tfvars`, gitignored, or
+   `TF_VAR_*`):
+   ```
+   export TF_VAR_domain_name="yournewdomain.com"          # purchased on GoDaddy
+   export TF_VAR_ec2_instance_name_tag="private-chatbot"  # match the real Name tag
+   ```
+3. `terraform plan` / `terraform apply`.
+
+## Connecting the GoDaddy domain
+
+**Option A — Route 53 authoritative (default, `manage_route53_zone = true`)**
+1. `terraform apply` creates the hosted zone.
+2. Read the `route53_name_servers` output.
+3. In GoDaddy: Domain Settings → Nameservers → Custom → paste those 4 values.
+4. Everything else (ACM validation, apex/cookbook records) is wired up by
+   Terraform automatically once the nameservers propagate.
+
+**Option B — GoDaddy stays authoritative (`manage_route53_zone = false`)**
+1. `terraform apply` (this will not create a Route 53 zone or validate the
+   cert automatically).
+2. Read the `manual_dns_records` output and the ACM console's
+   `domain_validation_options` for the exact CNAME records to add.
+3. In GoDaddy's DNS panel, add those CNAME records plus a CNAME/ALIAS for
+   the apex and cookbook subdomain pointing at the two
+   `*_cloudfront_domain_name` outputs (GoDaddy supports CNAME flattening at
+   the apex; otherwise use `www` and redirect the apex).
+4. Once ACM shows the cert as `ISSUED`, re-run `terraform apply` if the
+   CloudFront distributions were created before validation completed.
+
+## After the first apply
+
+- Configure the backend (`packages/backend`) to read
+  `origin_verify_header_value` (sensitive output) and reject any request
+  missing a matching `X-Panacea-Origin-Verify` header — the backend port has
+  to stay open to `0.0.0.0/0` since CloudFront has no stable IP range, so
+  this header is the only thing stopping direct hits on the EC2 instance.
+- Push the built web app (`packages/web/dist`) to the `web_s3_bucket`
+  output and invalidate the `web` CloudFront distribution.
+- Push the built docs (`packages/docs/site`, `mkdocs build`) to the
+  `cookbook_s3_bucket` output and invalidate the `cookbook` distribution.
+- `.github/workflows/deploy-panacea.yml` automates both of the above plus
+  the backend redeploy over SSH — see that file and the root `DEPLOYMENT.md`.
+
+## What this does NOT cover
+
+- **VS Code extension, CLI, desktop app**: already handled by
+  `.github/workflows/release.yml` (npm / VS Code Marketplace / GitHub
+  Releases on `v*` tags) — unrelated to this AWS stack.
+- **Mobile app**: not yet wired into CI — needs an EAS (Expo) build/submit
+  step once App Store/Play Store credentials exist. Tracked as a TODO in
+  the root `DEPLOYMENT.md`.
+- **Import of the existing EC2 instance into state**: intentionally left
+  out — this stack only reads the instance via a data source and never
+  manages its lifecycle, so there's nothing to import.

--- a/terraform/panacea/acm.tf
+++ b/terraform/panacea/acm.tf
@@ -1,0 +1,39 @@
+# CloudFront requires the certificate to live in us-east-1, hence the
+# provider alias regardless of var.aws_region.
+resource "aws_acm_certificate" "site" {
+  provider                 = aws.us_east_1
+  domain_name               = var.domain_name
+  subject_alternative_names = ["${var.cookbook_subdomain}.${var.domain_name}"]
+  validation_method         = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Only auto-validates when Route 53 is authoritative for the zone. With
+# external (GoDaddy) DNS, apply the CNAME records from the
+# `manual_dns_records` output by hand and the certificate validates itself
+# once GoDaddy's DNS propagates.
+resource "aws_route53_record" "cert_validation" {
+  for_each = var.manage_route53_zone ? {
+    for dvo in aws_acm_certificate.site.domain_validation_options : dvo.domain_name => {
+      name  = dvo.resource_record_name
+      type  = dvo.resource_record_type
+      value = dvo.resource_record_value
+    }
+  } : {}
+
+  zone_id = aws_route53_zone.this[0].zone_id
+  name    = each.value.name
+  type    = each.value.type
+  ttl     = 60
+  records = [each.value.value]
+}
+
+resource "aws_acm_certificate_validation" "site" {
+  count                   = var.manage_route53_zone ? 1 : 0
+  provider                = aws.us_east_1
+  certificate_arn         = aws_acm_certificate.site.arn
+  validation_record_fqdns = [for r in aws_route53_record.cert_validation : r.fqdn]
+}

--- a/terraform/panacea/acm.tf
+++ b/terraform/panacea/acm.tf
@@ -1,7 +1,7 @@
 # CloudFront requires the certificate to live in us-east-1, hence the
 # provider alias regardless of var.aws_region.
 resource "aws_acm_certificate" "site" {
-  provider                 = aws.us_east_1
+  provider                  = aws.us_east_1
   domain_name               = var.domain_name
   subject_alternative_names = ["${var.cookbook_subdomain}.${var.domain_name}"]
   validation_method         = "DNS"

--- a/terraform/panacea/cloudfront.tf
+++ b/terraform/panacea/cloudfront.tf
@@ -40,9 +40,9 @@ resource "aws_cloudfront_distribution" "web" {
 
     custom_origin_config {
       http_port              = var.backend_port
-      https_port              = 443
-      origin_protocol_policy  = "http-only"
-      origin_ssl_protocols    = ["TLSv1.2"]
+      https_port             = 443
+      origin_protocol_policy = "http-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
     }
 
     custom_header {
@@ -52,11 +52,11 @@ resource "aws_cloudfront_distribution" "web" {
   }
 
   default_cache_behavior {
-    allowed_methods         = ["GET", "HEAD", "OPTIONS"]
-    cached_methods           = ["GET", "HEAD"]
-    target_origin_id         = "s3-web"
-    viewer_protocol_policy   = "redirect-to-https"
-    compress                 = true
+    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "s3-web"
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = true
 
     forwarded_values {
       query_string = false
@@ -67,14 +67,14 @@ resource "aws_cloudfront_distribution" "web" {
   dynamic "ordered_cache_behavior" {
     for_each = ["/api/*", "/auth/*", "/health"]
     content {
-      path_pattern            = ordered_cache_behavior.value
-      allowed_methods          = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
-      cached_methods            = ["GET", "HEAD"]
-      target_origin_id          = "ec2-backend"
-      viewer_protocol_policy    = "redirect-to-https"
-      min_ttl                   = 0
-      default_ttl                = 0
-      max_ttl                    = 0
+      path_pattern           = ordered_cache_behavior.value
+      allowed_methods        = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+      cached_methods         = ["GET", "HEAD"]
+      target_origin_id       = "ec2-backend"
+      viewer_protocol_policy = "redirect-to-https"
+      min_ttl                = 0
+      default_ttl            = 0
+      max_ttl                = 0
 
       forwarded_values {
         query_string = true
@@ -110,10 +110,10 @@ resource "aws_cloudfront_distribution" "cookbook" {
 
   default_cache_behavior {
     allowed_methods        = ["GET", "HEAD", "OPTIONS"]
-    cached_methods          = ["GET", "HEAD"]
-    target_origin_id        = "s3-cookbook"
-    viewer_protocol_policy  = "redirect-to-https"
-    compress                = true
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "s3-cookbook"
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = true
 
     forwarded_values {
       query_string = false

--- a/terraform/panacea/cloudfront.tf
+++ b/terraform/panacea/cloudfront.tf
@@ -1,0 +1,142 @@
+locals {
+  # Shared secret CloudFront attaches to every request it forwards to the
+  # backend. The EC2-hosted Flask app should reject anything missing/wrong
+  # here, since the backend port itself has to stay open to 0.0.0.0/0.
+  origin_verify_header = "X-Panacea-Origin-Verify"
+}
+
+resource "aws_cloudfront_origin_access_control" "web" {
+  name                              = "${var.project_name}-web-oac"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_origin_access_control" "cookbook" {
+  name                              = "${var.project_name}-cookbook-oac"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+# ── Web app distribution ─────────────────────────────────────────────────────
+# Default behavior serves the built Vite app from S3; /api, /auth, and
+# /health are routed to the existing EC2 instance so the SPA can keep using
+# same-origin relative paths in production.
+resource "aws_cloudfront_distribution" "web" {
+  enabled             = true
+  default_root_object = var.web_index_document
+  aliases             = [var.domain_name]
+
+  origin {
+    domain_name              = aws_s3_bucket.web.bucket_regional_domain_name
+    origin_id                = "s3-web"
+    origin_access_control_id = aws_cloudfront_origin_access_control.web.id
+  }
+
+  origin {
+    domain_name = data.aws_instance.backend.public_dns
+    origin_id   = "ec2-backend"
+
+    custom_origin_config {
+      http_port              = var.backend_port
+      https_port              = 443
+      origin_protocol_policy  = "http-only"
+      origin_ssl_protocols    = ["TLSv1.2"]
+    }
+
+    custom_header {
+      name  = local.origin_verify_header
+      value = random_password.origin_verify.result
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods         = ["GET", "HEAD", "OPTIONS"]
+    cached_methods           = ["GET", "HEAD"]
+    target_origin_id         = "s3-web"
+    viewer_protocol_policy   = "redirect-to-https"
+    compress                 = true
+
+    forwarded_values {
+      query_string = false
+      cookies { forward = "none" }
+    }
+  }
+
+  dynamic "ordered_cache_behavior" {
+    for_each = ["/api/*", "/auth/*", "/health"]
+    content {
+      path_pattern            = ordered_cache_behavior.value
+      allowed_methods          = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+      cached_methods            = ["GET", "HEAD"]
+      target_origin_id          = "ec2-backend"
+      viewer_protocol_policy    = "redirect-to-https"
+      min_ttl                   = 0
+      default_ttl                = 0
+      max_ttl                    = 0
+
+      forwarded_values {
+        query_string = true
+        headers      = ["Authorization", "Content-Type"]
+        cookies { forward = "all" }
+      }
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn = aws_acm_certificate.site.arn
+    ssl_support_method  = "sni-only"
+  }
+}
+
+# ── Cookbook / docs distribution ─────────────────────────────────────────────
+resource "aws_cloudfront_distribution" "cookbook" {
+  enabled             = true
+  default_root_object = var.web_index_document
+  aliases             = ["${var.cookbook_subdomain}.${var.domain_name}"]
+
+  origin {
+    domain_name              = aws_s3_bucket.cookbook.bucket_regional_domain_name
+    origin_id                = "s3-cookbook"
+    origin_access_control_id = aws_cloudfront_origin_access_control.cookbook.id
+  }
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
+    cached_methods          = ["GET", "HEAD"]
+    target_origin_id        = "s3-cookbook"
+    viewer_protocol_policy  = "redirect-to-https"
+    compress                = true
+
+    forwarded_values {
+      query_string = false
+      cookies { forward = "none" }
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn = aws_acm_certificate.site.arn
+    ssl_support_method  = "sni-only"
+  }
+}
+
+# Rotated on every `terraform apply` that touches this resource; that's fine
+# since it's only there to stop stray direct hits on the EC2 instance's
+# public port, not to act as real authentication.
+resource "random_password" "origin_verify" {
+  length  = 32
+  special = false
+}

--- a/terraform/panacea/data.tf
+++ b/terraform/panacea/data.tf
@@ -1,0 +1,19 @@
+# The existing Private Chatbot EC2 instance Panacea's backend gets deployed
+# onto. Looked up by tag rather than created here — see variables.tf for why.
+data "aws_instance" "backend" {
+  filter {
+    name   = "tag:Name"
+    values = [var.ec2_instance_name_tag]
+  }
+
+  filter {
+    name   = "instance-state-name"
+    values = ["running"]
+  }
+}
+
+# The instance's primary security group, so we can open the backend port to
+# CloudFront without touching any of its other existing rules.
+data "aws_security_group" "backend" {
+  id = data.aws_instance.backend.vpc_security_group_ids[0]
+}

--- a/terraform/panacea/network.tf
+++ b/terraform/panacea/network.tf
@@ -1,0 +1,14 @@
+# Open the backend port on the existing instance's security group so
+# CloudFront can reach it. CloudFront doesn't publish a stable IP range, so
+# this has to stay open to 0.0.0.0/0 — pair it with the
+# X-Panacea-Origin-Verify custom header check in cloudfront.tf so the
+# backend rejects requests that didn't come through CloudFront.
+resource "aws_security_group_rule" "backend_from_cloudfront" {
+  type              = "ingress"
+  from_port         = var.backend_port
+  to_port           = var.backend_port
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = data.aws_security_group.backend.id
+  description       = "Panacea backend, fronted by CloudFront"
+}

--- a/terraform/panacea/outputs.tf
+++ b/terraform/panacea/outputs.tf
@@ -1,0 +1,43 @@
+output "web_cloudfront_domain_name" {
+  value = aws_cloudfront_distribution.web.domain_name
+}
+
+output "cookbook_cloudfront_domain_name" {
+  value = aws_cloudfront_distribution.cookbook.domain_name
+}
+
+output "web_s3_bucket" {
+  value = aws_s3_bucket.web.bucket
+}
+
+output "cookbook_s3_bucket" {
+  value = aws_s3_bucket.cookbook.bucket
+}
+
+output "backend_instance_id" {
+  value = data.aws_instance.backend.id
+}
+
+output "backend_public_dns" {
+  value = data.aws_instance.backend.public_dns
+}
+
+output "origin_verify_header_value" {
+  description = "Set this as the value the Flask backend expects on X-Panacea-Origin-Verify"
+  value       = random_password.origin_verify.result
+  sensitive   = true
+}
+
+output "route53_name_servers" {
+  description = "If manage_route53_zone = true, point GoDaddy's nameservers (Domain Settings > Nameservers > Custom) at these"
+  value       = var.manage_route53_zone ? aws_route53_zone.this[0].name_servers : []
+}
+
+output "manual_dns_records" {
+  description = "If manage_route53_zone = false, create these records in GoDaddy's DNS panel by hand"
+  value = var.manage_route53_zone ? tomap({}) : tomap({
+    "${var.domain_name}"                                 = "ALIAS/ANAME (or A via GoDaddy's flattening) -> ${aws_cloudfront_distribution.web.domain_name}"
+    "${var.cookbook_subdomain}.${var.domain_name}"        = "CNAME -> ${aws_cloudfront_distribution.cookbook.domain_name}"
+    "ACM validation (see `aws acm describe-certificate`)" = "CNAME records from aws_acm_certificate.site.domain_validation_options"
+  })
+}

--- a/terraform/panacea/outputs.tf
+++ b/terraform/panacea/outputs.tf
@@ -36,7 +36,7 @@ output "route53_name_servers" {
 output "manual_dns_records" {
   description = "If manage_route53_zone = false, create these records in GoDaddy's DNS panel by hand"
   value = var.manage_route53_zone ? tomap({}) : tomap({
-    "${var.domain_name}"                                 = "ALIAS/ANAME (or A via GoDaddy's flattening) -> ${aws_cloudfront_distribution.web.domain_name}"
+    "${var.domain_name}"                                  = "ALIAS/ANAME (or A via GoDaddy's flattening) -> ${aws_cloudfront_distribution.web.domain_name}"
     "${var.cookbook_subdomain}.${var.domain_name}"        = "CNAME -> ${aws_cloudfront_distribution.cookbook.domain_name}"
     "ACM validation (see `aws acm describe-certificate`)" = "CNAME records from aws_acm_certificate.site.domain_validation_options"
   })

--- a/terraform/panacea/route53.tf
+++ b/terraform/panacea/route53.tf
@@ -1,0 +1,34 @@
+# Optional — see the `manage_route53_zone` description in variables.tf.
+# When false, this file creates nothing and DNS stays fully on GoDaddy;
+# use the `manual_dns_records` output to fill in GoDaddy's DNS panel by hand.
+
+resource "aws_route53_zone" "this" {
+  count = var.manage_route53_zone ? 1 : 0
+  name  = var.domain_name
+}
+
+resource "aws_route53_record" "apex" {
+  count   = var.manage_route53_zone ? 1 : 0
+  zone_id = aws_route53_zone.this[0].zone_id
+  name    = var.domain_name
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.web.domain_name
+    zone_id                = aws_cloudfront_distribution.web.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "cookbook" {
+  count   = var.manage_route53_zone ? 1 : 0
+  zone_id = aws_route53_zone.this[0].zone_id
+  name    = "${var.cookbook_subdomain}.${var.domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.cookbook.domain_name
+    zone_id                = aws_cloudfront_distribution.cookbook.hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/terraform/panacea/s3.tf
+++ b/terraform/panacea/s3.tf
@@ -1,0 +1,64 @@
+# Static hosting for the Panacea web app and the developer cookbook/docs
+# site. Both buckets are private — CloudFront reaches them only via OAC.
+
+resource "aws_s3_bucket" "web" {
+  bucket = "${var.project_name}-${var.environment}-web"
+}
+
+resource "aws_s3_bucket_public_access_block" "web" {
+  bucket                  = aws_s3_bucket.web.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "web" {
+  bucket = aws_s3_bucket.web.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "cloudfront.amazonaws.com" }
+      Action    = "s3:GetObject"
+      Resource  = "${aws_s3_bucket.web.arn}/*"
+      Condition = {
+        StringEquals = {
+          "AWS:SourceArn" = aws_cloudfront_distribution.web.arn
+        }
+      }
+    }]
+  })
+}
+
+resource "aws_s3_bucket" "cookbook" {
+  bucket = "${var.project_name}-${var.environment}-cookbook"
+}
+
+resource "aws_s3_bucket_public_access_block" "cookbook" {
+  bucket                  = aws_s3_bucket.cookbook.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "cookbook" {
+  bucket = aws_s3_bucket.cookbook.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "cloudfront.amazonaws.com" }
+      Action    = "s3:GetObject"
+      Resource  = "${aws_s3_bucket.cookbook.arn}/*"
+      Condition = {
+        StringEquals = {
+          "AWS:SourceArn" = aws_cloudfront_distribution.cookbook.arn
+        }
+      }
+    }]
+  })
+}

--- a/terraform/panacea/variables.tf
+++ b/terraform/panacea/variables.tf
@@ -1,0 +1,66 @@
+variable "aws_region" {
+  description = "AWS region the existing Private Chatbot EC2 instance lives in"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "environment" {
+  description = "Deployment environment name (production, staging)"
+  type        = string
+  default     = "production"
+}
+
+variable "project_name" {
+  description = "Short name used to prefix all resources"
+  type        = string
+  default     = "panacea"
+}
+
+# ── Existing compute (reused, not created) ──────────────────────────────────
+# Panacea reuses the existing Private Chatbot EC2 instance instead of
+# standing up new ECS/Fargate/RDS resources, which is what keeps this stack
+# inside the ≤$100/month budget target. Terraform only *reads* this instance
+# (via a data source) and adds a security group rule to it — it never
+# creates or replaces the instance itself.
+variable "ec2_instance_name_tag" {
+  description = "Value of the Name tag on the existing Private Chatbot EC2 instance to deploy Panacea's backend onto"
+  type        = string
+  default     = "private-chatbot"
+}
+
+variable "backend_port" {
+  description = "Port the Panacea backend container listens on on the EC2 instance"
+  type        = number
+  default     = 5000
+}
+
+# ── Domain ───────────────────────────────────────────────────────────────────
+variable "domain_name" {
+  description = "New domain purchased on GoDaddy for Panacea (e.g. usepanacea.dev)"
+  type        = string
+}
+
+variable "cookbook_subdomain" {
+  description = "Subdomain the developer cookbook/docs site is served from"
+  type        = string
+  default     = "cookbook"
+}
+
+variable "manage_route53_zone" {
+  description = <<-EOT
+    If true, Terraform creates a Route 53 hosted zone and all DNS records for
+    var.domain_name, and you point GoDaddy's nameservers at Route 53
+    (Domain Settings > Nameservers > Custom, using the zone's `name_servers`
+    output). If false, GoDaddy stays authoritative for DNS and you manually
+    create the CNAME/ACM-validation records Terraform prints in the
+    `manual_dns_records` output.
+  EOT
+  type        = bool
+  default     = true
+}
+
+# ── S3 / CloudFront ──────────────────────────────────────────────────────────
+variable "web_index_document" {
+  type    = string
+  default = "index.html"
+}

--- a/terraform/panacea/versions.tf
+++ b/terraform/panacea/versions.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+
+  backend "s3" {
+    # Configure via `terraform init -backend-config=...` or a backend.hcl file.
+    # Use a key distinct from the main anote-ai stack so state never collides:
+    #   bucket = "anote-terraform-state"
+    #   key    = "panacea/terraform.tfstate"
+    #   region = "us-east-1"
+  }
+}
+
+# CloudFront + ACM certs for CloudFront must be requested in us-east-1
+# regardless of where everything else runs, so we alias the provider even
+# though the default region is already us-east-1.
+provider "aws" {
+  region = var.aws_region
+}
+
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}


### PR DESCRIPTION
## Summary
- Adds `terraform/panacea/` — a budget-conscious stack (S3, CloudFront, Route53/ACM) that reuses the existing Private Chatbot EC2 instance via a data source (no new RDS/ALB/Fargate), keeping Panacea under the ≤$100/month target. See `terraform/panacea/README.md` for the cost breakdown and setup.
- Adds `.github/workflows/deploy-panacea.yml` — auto-deploys staging (backend over SSH, web app + cookbook/docs to S3/CloudFront) on push to `develop`; production is a manual `workflow_dispatch`.
- Adds `docker-compose.panacea.yml` for running just the backend container on the existing EC2 instance.
- Adds `DEPLOYMENT.md` unifying the new Panacea track with the existing manual S3/Elastic Beanstalk runbook for the legacy anote.ai product, including the full list of GitHub secrets each pipeline needs.
- Closes gaps in `release.yml`: adds missing `publish-sdk-ts` (npm) and `publish-sdk-py` (PyPI) jobs, adds a `publish-mobile` job (EAS build), and fixes `packages/desktop/forge.config.js`, which was publishing GitHub Releases to the old `anote-ai/Autonomous-Intelligence` repo instead of this one. Also fixes stale repo URLs in `packages/sdk-py/pyproject.toml`.

## Test plan
- [ ] `terraform -chdir=terraform/panacea init && terraform validate` (no terraform binary available in this environment to run it here)
- [ ] Fill in the GitHub secrets listed in `DEPLOYMENT.md`, then dry-run `deploy-panacea.yml` against staging
- [ ] Confirm `release.yml`'s new jobs succeed on a test tag once `NPM_TOKEN`, `PYPI_API_TOKEN`, and `EXPO_TOKEN` secrets are set
- [ ] Existing CI (`ci.yml`) passes unchanged

Note: mobile app *build* is now automated via EAS, but *submission* to the App Store/Play Store still needs real Apple/Google credentials filled into `packages/mobile/eas.json` — flagged as a follow-up in `DEPLOYMENT.md`.

https://claude.ai/code/session_01M88y1CsP7aWYT63tA9VF79


---
_Generated by [Claude Code](https://claude.ai/code/session_01M88y1CsP7aWYT63tA9VF79)_