### PR TITLE
feat: consolidate CLI and VS Code agent parity

### DIFF
--- a/packages/cli/src/__tests__/config.test.ts
+++ b/packages/cli/src/__tests__/config.test.ts
@@ -41,4 +41,27 @@ describe("loadConfig()", () => {
     const config = loadConfig(tmpDir);
     expect(config).toEqual({});
   });
+
+  it("loads MCP server config (stdio + http)", () => {
+    const configData = {
+      mcpServers: {
+        github: { command: "npx", args: ["-y", "@modelcontextprotocol/server-github"] },
+        docs: { type: "http", url: "https://example.com/mcp" },
+      },
+    };
+    fs.writeFileSync(
+      path.join(tmpDir, ".anote.json"),
+      JSON.stringify(configData),
+      "utf8"
+    );
+    const config = loadConfig(tmpDir);
+    expect(config.mcpServers?.github).toEqual({
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-github"],
+    });
+    expect(config.mcpServers?.docs).toEqual({
+      type: "http",
+      url: "https://example.com/mcp",
+    });
+  });
 });

--- a/packages/cli/src/agent.ts
+++ b/packages/cli/src/agent.ts
@@ -12,7 +12,7 @@ export interface AgentRunOptions {
   prompt: string;
   cwd?: string;
   allowedTools?: string[];
-  permissionMode?: "default" | "acceptEdits" | "bypassPermissions";
+  permissionMode?: "default" | "acceptEdits" | "bypassPermissions" | "plan";
   systemPrompt?: string;
   maxTurns?: number;
   model?: string;
@@ -65,7 +65,7 @@ export async function runAgentStream(opts: AgentRunOptions): Promise<string> {
     }
   }
 
-  const allowedTools = opts.allowedTools ?? ["Read", "Write", "Edit", "Bash", "Glob", "Grep"];
+  const allowedTools = opts.allowedTools ?? ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "WebSearch", "WebFetch"];
   const maxTurns = opts.maxTurns ?? config.maxTurns ?? 30;
   const model = opts.model ?? config.model ?? "";
 

--- a/packages/cli/src/agent.ts
+++ b/packages/cli/src/agent.ts
@@ -86,12 +86,20 @@ export async function runAgentStream(opts: AgentRunOptions): Promise<string> {
   }
 
   // ── Anthropic path — claude-agent-sdk ────────────────────────────────────
+  // Wire configured MCP servers and auto-allow their tools (mcp__<server>).
+  const mcpServers = config.mcpServers;
+  const mcpAllow = mcpServers ? Object.keys(mcpServers).map((s) => `mcp__${s}`) : [];
+  if (mcpAllow.length) {
+    console.log(chalk.gray(`  (MCP: ${Object.keys(mcpServers!).join(", ")})\n`));
+  }
+
   const options: Options = {
     cwd,
-    allowedTools,
+    allowedTools: [...allowedTools, ...mcpAllow],
     permissionMode: opts.permissionMode ?? config.permissionMode ?? "default",
     systemPrompt,
     maxTurns,
+    ...(mcpServers ? { mcpServers: mcpServers as Options["mcpServers"] } : {}),
   };
 
   let result = "";

--- a/packages/cli/src/agent.ts
+++ b/packages/cli/src/agent.ts
@@ -86,16 +86,16 @@ export async function runAgentStream(opts: AgentRunOptions): Promise<string> {
   }
 
   // ── Anthropic path — claude-agent-sdk ────────────────────────────────────
-  // Wire configured MCP servers and auto-allow their tools (mcp__<server>).
+  // Wire configured MCP servers. Their tools remain subject to the SDK's
+  // normal permission flow because tool names are only known after discovery.
   const mcpServers = config.mcpServers;
-  const mcpAllow = mcpServers ? Object.keys(mcpServers).map((s) => `mcp__${s}`) : [];
-  if (mcpAllow.length) {
-    console.log(chalk.gray(`  (MCP: ${Object.keys(mcpServers!).join(", ")})\n`));
+  if (mcpServers && Object.keys(mcpServers).length) {
+    console.log(chalk.gray(`  (MCP: ${Object.keys(mcpServers).join(", ")})\n`));
   }
 
   const options: Options = {
     cwd,
-    allowedTools: [...allowedTools, ...mcpAllow],
+    allowedTools,
     permissionMode: opts.permissionMode ?? config.permissionMode ?? "default",
     systemPrompt,
     maxTurns,

--- a/packages/cli/src/commands/ask.ts
+++ b/packages/cli/src/commands/ask.ts
@@ -30,6 +30,7 @@ export function askCommand(): Command {
     .option("-d, --dir <path>", "working directory", process.cwd())
     .option("-f, --file <path>", "focus on a specific file")
     .option("--no-edit", "read-only mode, no file modifications")
+    .option("--plan", "planning mode: reason through the task read-only, no edits or commands")
     .option("--compare", "run the same prompt across multiple models side by side")
     .option(
       "--models <list>",
@@ -109,9 +110,9 @@ export function askCommand(): Command {
               cwd,
               model,
               allowedTools: opts.edit
-                ? ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
-                : ["Read", "Glob", "Grep"],
-              permissionMode: "default",
+                ? ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "WebSearch", "WebFetch"]
+                : ["Read", "Glob", "Grep", "WebSearch", "WebFetch"],
+              permissionMode: opts.plan ? "plan" : "default",
               showToolUse: false,
             });
           } catch (err) {

--- a/packages/cli/src/commands/chat.ts
+++ b/packages/cli/src/commands/chat.ts
@@ -9,6 +9,7 @@ export function chatCommand(): Command {
     .description("Start an interactive chat session with the AI assistant")
     .option("-d, --dir <path>", "working directory", process.cwd())
     .option("-m, --model <model>", "model to use", "claude-sonnet-4-6")
+    .option("--plan", "planning mode: reason through the task read-only, no edits or commands")
     .action(async (opts) => {
       const cwd = opts.dir as string;
       const model = opts.model as string;
@@ -44,8 +45,8 @@ export function chatCommand(): Command {
               prompt: message,
               cwd,
               model,
-              allowedTools: ["Read", "Glob", "Grep"],
-              permissionMode: "default",
+              allowedTools: ["Read", "Glob", "Grep", "WebSearch", "WebFetch"],
+              permissionMode: opts.plan ? "plan" : "default",
             });
           } catch (err) {
             console.error(chalk.red(`\nError: ${err instanceof Error ? err.message : String(err)}`));

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -1,0 +1,97 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import { loadConfig, type AnoteConfig, type McpServerConfig } from "../config.js";
+
+const GLOBAL_CONFIG_PATH = path.join(os.homedir(), ".anote", "config.json");
+
+function readGlobalConfig(): AnoteConfig {
+  if (!fs.existsSync(GLOBAL_CONFIG_PATH)) return {};
+  try {
+    return JSON.parse(fs.readFileSync(GLOBAL_CONFIG_PATH, "utf8")) as AnoteConfig;
+  } catch {
+    return {};
+  }
+}
+
+function writeGlobalConfig(cfg: AnoteConfig): void {
+  const dir = path.dirname(GLOBAL_CONFIG_PATH);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(GLOBAL_CONFIG_PATH, JSON.stringify(cfg, null, 2) + "\n");
+}
+
+function describeServer(cfg: McpServerConfig): string {
+  if ("command" in cfg) {
+    return chalk.gray(`stdio: ${cfg.command}${cfg.args?.length ? " " + cfg.args.join(" ") : ""}`);
+  }
+  return chalk.gray(`${cfg.type}: ${cfg.url}`);
+}
+
+export function mcpCommand(): Command {
+  const cmd = new Command("mcp").description("Manage MCP (Model Context Protocol) servers");
+
+  cmd
+    .command("list", { isDefault: true })
+    .alias("ls")
+    .description("List configured MCP servers")
+    .action(() => {
+      const servers = loadConfig(process.cwd()).mcpServers ?? {};
+      const names = Object.keys(servers);
+      if (!names.length) {
+        console.log(
+          chalk.gray("\nNo MCP servers configured.") +
+            `\n  Add one:  ${chalk.cyan("anote mcp add <name> -- <command> [args…]")}\n`
+        );
+        return;
+      }
+      console.log(chalk.bold("\nMCP servers\n"));
+      for (const name of names) {
+        console.log(`  ${chalk.green(name.padEnd(22))} ${describeServer(servers[name])}`);
+      }
+      console.log("");
+    });
+
+  cmd
+    .command("add <name> [args...]")
+    .description("Add a stdio MCP server to global config (command after --)")
+    .action((name: string, args: string[]) => {
+      const parts = args[0] === "--" ? args.slice(1) : args;
+      if (!parts.length) {
+        console.error(
+          chalk.red("✗ Provide the server command, e.g.\n  ") +
+            chalk.cyan("anote mcp add github -- npx -y @modelcontextprotocol/server-github")
+        );
+        process.exitCode = 1;
+        return;
+      }
+      const [command, ...rest] = parts;
+      const cfg = readGlobalConfig();
+      cfg.mcpServers = cfg.mcpServers ?? {};
+      cfg.mcpServers[name] = { command, ...(rest.length ? { args: rest } : {}) };
+      writeGlobalConfig(cfg);
+      console.log(
+        chalk.green("✓") +
+          ` Added MCP server ${chalk.bold(name)}  ${describeServer(cfg.mcpServers[name])}` +
+          chalk.gray(`  (${GLOBAL_CONFIG_PATH})`)
+      );
+    });
+
+  cmd
+    .command("remove <name>")
+    .alias("rm")
+    .description("Remove an MCP server from global config")
+    .action((name: string) => {
+      const cfg = readGlobalConfig();
+      if (!cfg.mcpServers || !(name in cfg.mcpServers)) {
+        console.log(chalk.yellow(`${name} is not configured — nothing to do.`));
+        return;
+      }
+      delete cfg.mcpServers[name];
+      writeGlobalConfig(cfg);
+      console.log(chalk.green("✓") + ` Removed MCP server ${chalk.bold(name)}`);
+    });
+
+  return cmd;
+}

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -12,6 +12,17 @@ export interface HookConfig {
   postToolUse?: string[];
 }
 
+/**
+ * MCP (Model Context Protocol) server config. Mirrors the shape accepted by
+ * `@anthropic-ai/claude-agent-sdk`'s `mcpServers` option so external tool
+ * servers (GitHub, Slack, databases, browsers, …) can be wired in. Only the
+ * Anthropic runtime path supports MCP; OpenAI/Gemini adapters ignore it.
+ */
+export type McpServerConfig =
+  | { type?: "stdio"; command: string; args?: string[]; env?: Record<string, string> }
+  | { type: "sse"; url: string; headers?: Record<string, string> }
+  | { type: "http"; url: string; headers?: Record<string, string> };
+
 export interface AnoteConfig {
   model?: string;
   permissionMode?: "default" | "acceptEdits" | "bypassPermissions";
@@ -22,6 +33,11 @@ export interface AnoteConfig {
   provider?: string;
   /** Base URL for OpenAI-compatible endpoints (e.g. http://localhost:11434/v1 for Ollama). */
   baseUrl?: string;
+  /**
+   * MCP servers to expose as tools, keyed by server name. Tools are surfaced to
+   * the model as `mcp__<server>__<tool>`. Anthropic runtime only.
+   */
+  mcpServers?: Record<string, McpServerConfig>;
 }
 
 const CONFIG_FILENAMES = [".anote.json", ".claw.json", "anote.config.json"];

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -25,7 +25,7 @@ export type McpServerConfig =
 
 export interface AnoteConfig {
   model?: string;
-  permissionMode?: "default" | "acceptEdits" | "bypassPermissions";
+  permissionMode?: "default" | "acceptEdits" | "bypassPermissions" | "plan";
   hooks?: HookConfig;
   maxTurns?: number;
   compactAfterMessages?: number;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,6 +24,7 @@ import { docsCommand } from "./commands/docs.js";
 import { changelogCommand } from "./commands/changelog.js";
 import { securityCommand } from "./commands/security.js";
 import { perfCommand } from "./commands/perf.js";
+import { mcpCommand } from "./commands/mcp.js";
 
 const LOGO = chalk.cyan(`
    ___                    _          _    ___
@@ -45,8 +46,11 @@ program
 
 program.addHelpText("beforeAll", LOGO);
 
-program.hook("preAction", (thisCommand) => {
-  if (thisCommand.name() === "init" || thisCommand.name() === "doctor") return;
+program.hook("preAction", () => {
+  // Setup/config-management commands don't talk to a model — skip the key gate.
+  // Use argv (not thisCommand.name()) so nested subcommands like `mcp list` match.
+  const topCmd = process.argv[2];
+  if (topCmd === "init" || topCmd === "doctor" || topCmd === "mcp") return;
   if (!process.env.ANTHROPIC_API_KEY) {
     console.error(
       chalk.red("\n✗ ANTHROPIC_API_KEY is not set.\n") +
@@ -84,6 +88,7 @@ program.addCommand(docsCommand());
 program.addCommand(changelogCommand());
 program.addCommand(securityCommand());
 program.addCommand(perfCommand());
+program.addCommand(mcpCommand());
 
 program.parseAsync(process.argv).catch((err: Error) => {
   console.error(chalk.red("Error:"), err.message);

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -200,6 +200,11 @@
           "type": "boolean",
           "default": true,
           "description": "Show Anote inline action buttons (CodeLens) above functions and classes"
+        },
+        "anote.mcpServers": {
+          "type": "object",
+          "default": {},
+          "markdownDescription": "MCP (Model Context Protocol) servers to expose as tools, keyed by name. Each value is a server config — stdio `{ \"command\": ..., \"args\": [...] }` or `{ \"type\": \"http\"|\"sse\", \"url\": ... }`. Anthropic runtime only. Example: `{ \"github\": { \"command\": \"npx\", \"args\": [\"-y\", \"@modelcontextprotocol/server-github\"] } }`"
         }
       }
     }

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -176,6 +176,11 @@
           "default": false,
           "description": "Automatically accept file edits without confirmation"
         },
+        "anote.planMode": {
+          "type": "boolean",
+          "default": false,
+          "description": "Plan mode: Anote researches and proposes a plan without editing files (read-only). Takes precedence over autoEdit when enabled."
+        },
         "anote.serverUrl": {
           "type": "string",
           "default": "",

--- a/packages/vscode/src/agent.ts
+++ b/packages/vscode/src/agent.ts
@@ -7,6 +7,7 @@ import type { Options, SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import {
   directRuntimeSupportMessage,
   getConfiguredApiKey,
+  getMcpServers,
   getModel,
   getProvider,
   getServerUrl,
@@ -160,13 +161,18 @@ export class AnoteAgent {
       prompt = `Previous conversation:\n${history}\n\nUser: ${prompt}`;
     }
 
+    // Wire configured MCP servers and auto-allow their tools (mcp__<server>).
+    const mcpServers = getMcpServers();
+    const mcpAllow = mcpServers ? Object.keys(mcpServers).map((s) => `mcp__${s}`) : [];
+
     const options: Options = {
       cwd,
-      allowedTools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"],
+      allowedTools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep", ...mcpAllow],
       permissionMode: this.isAutoEdit() ? "acceptEdits" : "default",
       systemPrompt,
       maxTurns: this.getMaxTurns(),
       model: getModel(),
+      ...(mcpServers ? { mcpServers: mcpServers as Options["mcpServers"] } : {}),
     };
 
     try {

--- a/packages/vscode/src/agent.ts
+++ b/packages/vscode/src/agent.ts
@@ -103,6 +103,10 @@ export class AnoteAgent {
     return vscode.workspace.getConfiguration("anote").get<boolean>("autoEdit") ?? false;
   }
 
+  private isPlanMode(): boolean {
+    return vscode.workspace.getConfiguration("anote").get<boolean>("planMode") ?? false;
+  }
+
   getCwdForWorkspace(): string {
     const folders = vscode.workspace.workspaceFolders;
     return folders && folders.length > 0 ? folders[0].uri.fsPath : process.cwd();
@@ -167,8 +171,22 @@ export class AnoteAgent {
 
     const options: Options = {
       cwd,
-      allowedTools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep", ...mcpAllow],
-      permissionMode: this.isAutoEdit() ? "acceptEdits" : "default",
+      allowedTools: [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash",
+        "Glob",
+        "Grep",
+        "WebSearch",
+        "WebFetch",
+        ...mcpAllow,
+      ],
+      permissionMode: this.isPlanMode()
+        ? "plan"
+        : this.isAutoEdit()
+          ? "acceptEdits"
+          : "default",
       systemPrompt,
       maxTurns: this.getMaxTurns(),
       model: getModel(),

--- a/packages/vscode/src/agent.ts
+++ b/packages/vscode/src/agent.ts
@@ -165,9 +165,9 @@ export class AnoteAgent {
       prompt = `Previous conversation:\n${history}\n\nUser: ${prompt}`;
     }
 
-    // Wire configured MCP servers and auto-allow their tools (mcp__<server>).
+    // Wire configured MCP servers. Their tools remain subject to the SDK's
+    // normal permission flow because tool names are only known after discovery.
     const mcpServers = getMcpServers();
-    const mcpAllow = mcpServers ? Object.keys(mcpServers).map((s) => `mcp__${s}`) : [];
 
     const options: Options = {
       cwd,
@@ -180,7 +180,6 @@ export class AnoteAgent {
         "Grep",
         "WebSearch",
         "WebFetch",
-        ...mcpAllow,
       ],
       permissionMode: this.isPlanMode()
         ? "plan"

--- a/packages/vscode/src/config.ts
+++ b/packages/vscode/src/config.ts
@@ -11,6 +11,20 @@ export type AnoteProvider =
 export const DEFAULT_PROVIDER: AnoteProvider = "anthropic";
 export const DEFAULT_MODEL = "claude-sonnet-4-6";
 
+/** MCP server config, mirroring `@anthropic-ai/claude-agent-sdk`'s mcpServers shape. */
+export type McpServerConfig =
+  | { type?: "stdio"; command: string; args?: string[]; env?: Record<string, string> }
+  | { type: "sse"; url: string; headers?: Record<string, string> }
+  | { type: "http"; url: string; headers?: Record<string, string> };
+
+/** MCP servers from the `anote.mcpServers` setting (Anthropic runtime only). */
+export function getMcpServers(): Record<string, McpServerConfig> | undefined {
+  const servers = vscode.workspace
+    .getConfiguration("anote")
+    .get<Record<string, McpServerConfig>>("mcpServers");
+  return servers && Object.keys(servers).length ? servers : undefined;
+}
+
 export function getProvider(): AnoteProvider {
   return (
     vscode.workspace.getConfiguration("anote").get<AnoteProvider>("provider") ??


### PR DESCRIPTION
## Summary

Consolidates the still-relevant work from #251, #253, and #258 into one clean branch based on the current `develop` branch.

- adds CLI MCP server configuration plus `anote mcp add/list/remove`
- wires configured MCP servers into the CLI and VS Code Anthropic runtimes
- adds Plan mode to CLI `ask`/`chat` and the VS Code extension
- enables `WebSearch` and `WebFetch` in both surfaces
- preserves the SDK permission flow for dynamically discovered MCP tools

## Scope

This PR supersedes #251, #253, and #258. It intentionally excludes the obsolete/superseded #259 and #263, and does not mix in #260, #261, or #262 because those need separate current-architecture/infrastructure review.

## Validation

- CLI TypeScript build passes
- CLI tests pass: 20/20
- VS Code TypeScript build passes
- SDK and web builds pass
- all workspace tests pass
