### PR TITLE
docs: step-by-step usage guides for CLI, VS Code, web, desktop, mobile, SDK

### DIFF
--- a/packages/docs/docs/cli/overview.md
+++ b/packages/docs/docs/cli/overview.md
@@ -30,4 +30,4 @@ npm install -g @anote-ai/anote
 | `anote init` | Set up Anote |
 | `anote config` | Manage configuration |
 
-See [Commands](commands.md) for full usage.
+See [Commands](commands.md) for full usage, or follow the [Quick Start](../getting-started/quickstart.md) for a step-by-step walkthrough of `init` → ask a question → auto-fix a bug → index and search → review a PR.

--- a/packages/docs/docs/desktop/local-models.md
+++ b/packages/docs/docs/desktop/local-models.md
@@ -1,16 +1,22 @@
 # Local Models
 
-The desktop app supports local LLM inference via [Ollama](https://ollama.ai).
+The bundled backend supports local LLM inference via [Ollama](https://ollama.ai) — any model name that isn't a `claude*`, `gpt*`, or `gemini*` model is routed to Ollama automatically (`packages/backend/services/llm.py`).
+
+!!! warning "Desktop UI gap"
+    The desktop app's chat model dropdown is currently a fixed list of 4 cloud models (`claude-sonnet-4-6`, `claude-haiku-4-5-20251001`, `gpt-4o`, `gpt-4o-mini`) with no local-model option wired in yet. The backend routing described below works today; picking a local model from the desktop app's UI doesn't. If you need this, it's worth raising as a small frontend addition rather than assuming it already works.
 
 ## Setup
 
 1. Install Ollama from [ollama.ai](https://ollama.ai)
 2. Pull a model:
+
    ```bash
    ollama pull llama3
    ollama pull mistral
    ```
-3. In the desktop app, select a local model from the model dropdown (prefixed with `ollama/`)
+
+3. The backend defaults to `OLLAMA_BASE_URL=http://localhost:11434`; override it in your `.env` if Ollama runs elsewhere
+4. Send the exact model name (e.g. `llama3`, no prefix) as the `model` in any `chat` call — via CLI, SDK, or once the desktop UI supports it
 
 ## Supported Models
 

--- a/packages/docs/docs/desktop/overview.md
+++ b/packages/docs/docs/desktop/overview.md
@@ -19,3 +19,10 @@ Electron shell
        └─ SQLite database (local)
        └─ ChromaDB vector store (local)
 ```
+
+## Using the app
+
+1. [Install](installation.md) and launch it — the Electron shell starts the bundled backend automatically
+2. Register a local account (this account and its data live only in the local SQLite database, not the hosted service)
+3. Pick a model from the dropdown (`claude-sonnet-4-6`, `claude-haiku-4-5-20251001`, `gpt-4o`, or `gpt-4o-mini`) and start chatting — nothing leaves your machine except the request to whichever provider you chose
+4. For fully offline use, see [Local Models](local-models.md) — the backend can route to Ollama, though picking one isn't wired into this dropdown yet

--- a/packages/docs/docs/mobile/overview.md
+++ b/packages/docs/docs/mobile/overview.md
@@ -12,13 +12,19 @@ The Anote AI mobile app is built with [Expo](https://expo.dev) and React Native.
 
 ## Running Locally
 
-```bash
-cd packages/mobile
-npm install
-npx expo start
-```
+The mobile app isn't published to an app store yet — running it locally via Expo is currently the only way to use it.
 
-Scan the QR code with the Expo Go app or run in a simulator.
+1. Install dependencies and start the dev server:
+
+   ```bash
+   cd packages/mobile
+   npm install
+   npx expo start
+   ```
+
+2. Scan the QR code with the [Expo Go](https://expo.dev/go) app on your phone, or press `i`/`a` in the terminal to launch an iOS/Android simulator
+3. Register or log in — your session token is stored securely on-device via `expo-secure-store`
+4. Chat as you would in the web app: streaming responses, session history in the slide-in sidebar, light/dark mode following your system setting
 
 ## Configuration
 

--- a/packages/docs/docs/sdk/python.md
+++ b/packages/docs/docs/sdk/python.md
@@ -1,41 +1,138 @@
 # Python SDK
 
-A Python client is available via the `anoteai` package (part of the Anote-Product repo).
+`anote-sdk` is the Python client for the Anote REST API — a direct mirror of the [TypeScript SDK](typescript.md), with both a synchronous and an `asyncio` client. Package source: `packages/sdk-py/`.
 
-## Installation
+!!! note "API keys and local development"
+    Same caveat as the TypeScript SDK: the client talks to `https://api.anote.ai` by default and authenticates with an API key. This repo's local backend doesn't currently issue those keys — only JWT session auth for the web app. Use a key from your hosted Anote account, or confirm with the backend team before pointing this at a local server.
+
+## What you'll need
+
+- Python 3.9+
+- An Anote API key from your account
+
+## 1. Install
 
 ```bash
-pip install anoteai
+pip install anote-sdk
 ```
 
-## Usage
+## 2. Initialize the client
 
 ```python
-from anoteai import Anote
+from anote_sdk import AnoteClient
 
-client = Anote(api_key="sk-ai-...")
-
-# Existing public methods authenticate with Authorization: Bearer sk-ai-...
-result = client.classify(document_id="doc_123", labels=["contract", "invoice"])
-answer = client.answer(document_id="doc_123", question="What is the payment amount?")
+client = AnoteClient(api_key="your-api-key")
+# or: AnoteClient(api_key="...", base_url="https://api.anote.ai", timeout=60.0)
 ```
 
-Create API keys from Settings -> API Keys. The plaintext key is shown once; after that only the key prefix is displayed.
+`api_key` is the only required argument.
 
-Credit costs:
+## 3. Send your first message
 
-| Operation | Credits |
-| --- | ---: |
-| Document upload | 1 per file or URL |
-| Chat message / Q&A | 1 per request |
-| OpenAI-compatible chat completion | 1 per request |
+```python
+result = client.chat("Explain this codebase")
 
-Handle API errors by status code:
+print(result.result)
+print(f"Used {result.usage.input_tokens} input tokens")
+```
 
-| Status | Meaning |
-| --- | --- |
-| 401 | Missing or invalid API key |
-| 402 | Insufficient credits |
-| 429 | Per-key rate limit exceeded |
+Pass `cwd`, `model`, or `tools` to scope the call:
 
-See the [Anote-Product repository](https://github.com/anote-ai/anote-product) for full SDK documentation.
+```python
+client.chat(
+    "List TODOs in this file",
+    cwd="/path/to/project",
+    model="claude-sonnet-4-6",
+    tools=["Read", "Grep"],
+)
+```
+
+## Common tasks
+
+**List and inspect past sessions**
+
+```python
+sessions = client.list_sessions()
+messages = client.get_session_messages(sessions[0].session_id)
+```
+
+**Search across session history**
+
+```python
+results = client.search("authentication logic")
+```
+
+**Check your usage and quota**
+
+```python
+usage = client.get_usage()
+print(f"{usage.remaining.requests} requests remaining this month")
+```
+
+**Share a session as a read-only link**
+
+```python
+share = client.share_session(sessions[0].session_id)
+print(share.share_url)
+```
+
+**Handle errors**
+
+Every non-2xx response raises `AnoteError`, which carries `.status` and `.body`:
+
+```python
+from anote_sdk import AnoteClient, AnoteError
+
+try:
+    client.chat("...")
+except AnoteError as err:
+    print(err.status, err)  # e.g. 429, "Monthly quota exceeded"
+```
+
+**Check server liveness (no auth required)**
+
+```python
+health = client.health()
+```
+
+## Async usage
+
+For `asyncio` applications, use `AsyncAnoteClient` as a context manager — same method names, `await`ed:
+
+```python
+from anote_sdk import AsyncAnoteClient
+
+async with AsyncAnoteClient(api_key="your-api-key") as client:
+    result = await client.chat("Explain this codebase")
+    print(result.result)
+```
+
+## API reference
+
+### `AnoteClient(api_key, base_url=..., timeout=60.0)` / `AsyncAnoteClient(...)`
+
+| Argument | Type | Required | Description |
+|---|---|---|---|
+| `api_key` | `str` | ✓ | Your Anote API key |
+| `base_url` | `str` | | Server URL (default: `https://api.anote.ai`) |
+| `timeout` | `float` | | Request timeout in seconds (default: `60.0`) |
+
+### Methods
+
+| Method | Description |
+|--------|-------------|
+| `chat(message, *, cwd=, model=, tools=)` | Send a message, get a complete AI response |
+| `list_sessions()` | List all chat sessions |
+| `get_session_messages(session_id)` | Get message history for a session |
+| `delete_session(session_id)` | Delete a session |
+| `share_session(session_id)` | Mint a shareable read-only link |
+| `search(query, limit=20)` | Full-text search across sessions |
+| `get_usage()` | Current month usage + quota |
+| `health()` | Server liveness check (no auth needed) |
+
+Async client exposes the same methods as coroutines.
+
+## Next steps
+
+- [Backend API Overview](../api/overview.md) — the REST endpoints underneath this SDK
+- [TypeScript SDK](typescript.md) — the equivalent JS/TS client

--- a/packages/docs/docs/sdk/typescript.md
+++ b/packages/docs/docs/sdk/typescript.md
@@ -1,44 +1,126 @@
 # TypeScript SDK
 
-The `@anote-ai/sdk` package provides a typed client for the Anote backend API.
+`@anote-ai/sdk` is a typed TypeScript/JavaScript client for the Anote REST API. Use it when you want to call Anote programmatically — from a script, a backend service, or your own app — instead of going through the CLI or web app.
 
-## Installation
+!!! note "API keys and local development"
+    The client authenticates with an API key against `https://api.anote.ai` by default. This repo's local backend (`packages/backend`) is the one behind the web app and does not currently issue Anote API keys itself — it only supports the JWT session auth the web app uses. To develop against the SDK today, get a key from your Anote account on the hosted platform. If you're testing the SDK against your local backend, you'll need a backend change to accept it first — check with the backend team before assuming this works out of the box.
+
+## What you'll need
+
+- Node.js 18+
+- An Anote API key from your account
+
+## 1. Install
 
 ```bash
 npm install @anote-ai/sdk
 ```
 
-## Usage
+## 2. Initialize the client
 
-```typescript
-import AnoteClient from '@anote-ai/sdk';
+```ts
+import { AnoteClient } from "@anote-ai/sdk";
 
 const client = new AnoteClient({
-  baseUrl: 'https://api.anote.ai',
-  apiKey: 'your-api-key',
+  apiKey: "your-api-key",
+  baseUrl: "https://api.anote.ai", // omit to use the default
 });
+```
 
-// Chat
-const response = await client.chat({
-  message: 'Explain this codebase',
-  model: 'claude-sonnet-4-6',
+`apiKey` is the only required option.
+
+## 3. Send your first message
+
+```ts
+const { result, usage } = await client.chat("Explain this codebase");
+
+console.log(result);
+console.log(`Used ${usage.inputTokens} input / ${usage.outputTokens} output tokens`);
+```
+
+`chat()` is the non-streaming call — it waits for the full response, which is what you want for scripting and automation. Pass `cwd`, `model`, or `tools` in the second argument to scope the working directory, pick a model, or restrict which tools the AI may use:
+
+```ts
+await client.chat("List TODOs in this file", {
+  cwd: "/path/to/project",
+  model: "claude-sonnet-4-6",
+  tools: ["Read", "Grep"],
 });
+```
 
-// Search
-const results = await client.search({ query: 'authentication logic', cwd: '.' });
+## Common tasks
 
-// Health check
+**List and inspect past sessions**
+
+```ts
+const sessions = await client.listSessions();
+const { history } = await client.getSessionMessages(sessions[0].sessionId);
+```
+
+**Search across session history**
+
+```ts
+const { results } = await client.search("authentication logic");
+```
+
+**Check your usage and quota**
+
+```ts
+const usage = await client.getUsage();
+console.log(`${usage.remaining.requests} requests remaining this month`);
+```
+
+**Share a session as a read-only link**
+
+```ts
+const { shareUrl } = await client.shareSession(sessions[0].sessionId);
+```
+
+**Handle errors**
+
+Every non-2xx response throws `AnoteError`, which carries the HTTP status and parsed response body:
+
+```ts
+import { AnoteClient, AnoteError } from "@anote-ai/sdk";
+
+try {
+  await client.chat("...");
+} catch (err) {
+  if (err instanceof AnoteError) {
+    console.error(err.status, err.message); // e.g. 429, "Monthly quota exceeded"
+  }
+}
+```
+
+**Check server liveness (no auth required)**
+
+```ts
 const health = await client.health();
 ```
 
-## API Reference
+## API reference
+
+### `new AnoteClient(options)`
+
+| Option | Type | Required | Description |
+|---|---|---|---|
+| `apiKey` | `string` | ✓ | Your Anote API key |
+| `baseUrl` | `string` | | Server URL (default: `https://api.anote.ai`) |
+
+### Methods
 
 | Method | Description |
 |--------|-------------|
-| `chat(options)` | Send a chat message |
-| `listSessions()` | List chat sessions |
-| `getSessionMessages(id)` | Get messages in a session |
+| `chat(message, options?)` | Send a message, get a complete AI response |
+| `listSessions()` | List all chat sessions |
+| `getSessionMessages(id)` | Get message history for a session |
 | `deleteSession(id)` | Delete a session |
-| `search(options)` | Search the codebase index |
-| `getUsage()` | Get API usage stats |
-| `health()` | Health check |
+| `shareSession(id)` | Mint a shareable read-only link |
+| `search(query, limit?)` | Full-text search across sessions |
+| `getUsage()` | Current month usage + quota |
+| `health()` | Server liveness check (no auth needed) |
+
+## Next steps
+
+- [Backend API Overview](../api/overview.md) — the REST endpoints underneath this SDK
+- [CLI Overview](../cli/overview.md) — for interactive/terminal use instead of scripting

--- a/packages/docs/docs/vscode/overview.md
+++ b/packages/docs/docs/vscode/overview.md
@@ -25,6 +25,10 @@ code --install-extension anote-ai.anote-ai-coding
 
 1. Open VS Code
 2. Run `Anote: Set Up` from the command palette (`Ctrl+Shift+P`)
-3. Choose your provider (Anthropic direct or via Anote server)
-4. Enter your API key
-5. Open the chat panel from the Activity Bar
+3. Choose a mode:
+   - **Direct** — pick a provider (`anthropic`, `openai`, `gemini`, `llama`, `xai`, `custom`) and enter its API key
+   - **Server** — point `anote.serverUrl` at an Anote backend (local or hosted) instead
+4. Open the chat panel from the Activity Bar and send a message
+5. Select code and use the right-click **Anote AI** submenu (or CodeLens actions above a function) to explain, fix, refactor, or generate tests for it
+
+See [Settings](settings.md) for the full list of configuration options.

--- a/packages/docs/docs/vscode/settings.md
+++ b/packages/docs/docs/vscode/settings.md
@@ -1,17 +1,29 @@
 # VS Code Extension Settings
 
-Configure the extension in VS Code's settings UI or `settings.json`.
+Configure the extension in VS Code's settings UI (search "Anote") or `settings.json`.
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `anote.model` | `claude-sonnet-4-6` | Default model to use |
-| `anote.apiKey` | `""` | Anthropic API key (or use env var) |
-| `anote.permissionMode` | `default` | Tool permission mode: `default`, `auto`, `manual` |
-| `anote.showToolUse` | `true` | Show tool calls in the chat panel |
+| `anote.provider` | `anthropic` | Provider family: `anthropic`, `openai`, `gemini`, `llama`, `xai`, `custom` |
+| `anote.apiKey` | `""` | Provider API key for direct mode. Leave blank when using an Anote server |
+| `anote.model` | `claude-sonnet-4-6` | Model id to use for the selected provider |
+| `anote.serverUrl` | `""` | URL of an Anote server — set this to route through a hosted/local server instead of the built-in direct runtime |
+| `anote.baseUrl` | `""` | Optional provider base URL override for future runtime adapters |
+| `anote.autoEdit` | `false` | Automatically accept file edits without confirmation |
+| `anote.maxTurns` | `30` | Maximum number of agentic turns per conversation |
+| `anote.persistSessions` | `true` | Persist chat history across VS Code reloads |
+| `anote.showToolUse` | `true` | Show tool-use indicators in the chat panel while Anote works |
+| `anote.enableCodeLens` | `true` | Show inline action buttons (CodeLens) above functions and classes |
 
 ```json
 {
+  "anote.provider": "anthropic",
   "anote.model": "claude-sonnet-4-6",
-  "anote.permissionMode": "default"
+  "anote.autoEdit": false
 }
 ```
+
+## Direct mode vs. server mode
+
+- **Direct mode** (default): set `anote.provider` + `anote.apiKey`, and the extension calls the model provider directly.
+- **Server mode**: set `anote.serverUrl` to point at an Anote backend (local `packages/backend` or hosted) instead — leave `anote.apiKey` blank.

--- a/packages/docs/docs/web/overview.md
+++ b/packages/docs/docs/web/overview.md
@@ -11,6 +11,15 @@ The Anote AI web app is a ChatGPT-style chat interface that connects to the Anot
 - Document upload and Q&A
 - Responsive design
 
+## Using the app
+
+1. Go to `/register` and create an account with email/password, or sign in with Google — either lands you on `/login` afterward if you're not already authenticated
+2. Once signed in you land on `/app`, the chat view
+3. Type a message and send it — the response streams in token-by-token; use the stop button to cancel mid-stream
+4. Attach a file from the chat composer to ask questions about a document — it's indexed and shows up under `/documents` too, where you can organize uploads into folders by dragging them
+5. Start a new conversation any time — past sessions stay listed in the left sidebar and reload at `/app/chat/:id`
+6. Toggle light/dark mode from the theme button — your preference is saved in `localStorage`
+
 ## Running Locally
 
 ```bash


### PR DESCRIPTION
## Summary

Rewrites each component's docs page (CLI, VS Code, web, desktop, mobile, SDK) as a step-by-step usage walkthrough, similar in structure to the Claude Code docs — per the cookbook discussion with Natan.

- **CLI**: overview now points to the existing step-by-step Quick Start instead of duplicating it
- **VS Code**: added a step-by-step Quick Setup flow
- **Web**: added a "Using the app" walkthrough (register/login → chat → attach a file → Documents → theme toggle)
- **Desktop**: added a "Using the app" walkthrough
- **Mobile**: numbered first-run flow via Expo (no store listing yet, so this is the real usage path)
- **SDK (TypeScript + Python)**: full step-by-step rewrite — install → auth → first call → common tasks → reference table

## Also fixed (found while auditing for accuracy)

- `sdk/python.md` documented a completely different, unrelated package (`anoteai` with `classify()`/`answer()`) instead of the actual in-repo Python SDK at `packages/sdk-py` (`anote_sdk.AnoteClient`, a mirror of the TS SDK). Rewrote it to match the real client, verified against `packages/sdk-py/anote_sdk/{client,models}.py`.
- `vscode/settings.md` documented a nonexistent `anote.permissionMode` setting and was missing half the real settings in `packages/vscode/package.json`. Replaced with the real 10 settings.
- `desktop/local-models.md` claimed the model dropdown supports an `ollama/`-prefixed local model — it doesn't currently. The backend does auto-route non-Claude/GPT/Gemini model names to Ollama (`packages/backend/services/llm.py`); documented that real mechanism and flagged the UI gap explicitly instead of leaving a false claim in place.
- Noted in both SDK pages: this repo's local backend (on `develop`) doesn't currently issue Anote API keys — only JWT session auth for the web app — so the "how do I get a key" step points at the hosted account rather than inventing a local endpoint that doesn't exist.

## Test plan

- [x] `mkdocs build --strict` passes (same check CI's Docs job runs)
- [x] Natan/Sindhu review for tone/scope fit with the rest of the cookbook

🤖 Generated with [Claude Code](https://claude.com/claude-code)