### PR TITLE
ci: wire opt-in macOS notarization and Windows code signing for deskt…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,42 @@ jobs:
         run: npm install && npm run build
       - working-directory: packages/desktop
         run: npm install
+
+      # --- Code signing (see issue #295 and packages/desktop/README.md) ---
+      # Both steps are no-ops until the relevant repo secrets are added, so
+      # today's unsigned build/publish is unaffected.
+      - name: Import Apple signing certificate
+        if: matrix.os == 'macos-latest' && secrets.APPLE_CERTIFICATE_P12 != ''
+        env:
+          APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 24)
+          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          echo "$APPLE_CERTIFICATE_P12" | base64 --decode > "$RUNNER_TEMP/apple-cert.p12"
+          security import "$RUNNER_TEMP/apple-cert.p12" -k build.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+          rm "$RUNNER_TEMP/apple-cert.p12"
+
+      - name: Decode Windows signing certificate
+        if: matrix.os == 'windows-latest' && secrets.CSC_LINK != ''
+        shell: pwsh
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+        run: |
+          $bytes = [Convert]::FromBase64String($env:CSC_LINK)
+          $certPath = Join-Path $env:RUNNER_TEMP "windows-cert.pfx"
+          [IO.File]::WriteAllBytes($certPath, $bytes)
+          echo "WINDOWS_CERTIFICATE_FILE=$certPath" >> $env:GITHUB_ENV
+
       - working-directory: packages/desktop
         run: npx electron-forge publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -27,3 +27,19 @@ npm run make
 ```
 
 Outputs in `out/` directory.
+
+## Code signing (releases)
+
+Release builds (`.github/workflows/release.yml`) are unsigned today, which means macOS Gatekeeper and Windows SmartScreen show security warnings on install — see [#295](https://github.com/anote-ai/Panacea/issues/295). Signing is already wired into `forge.config.js` and the release workflow; it activates automatically once these repo secrets exist (**Settings → Secrets and variables → Actions**), no code changes needed:
+
+| Secret | Platform | Description |
+|---|---|---|
+| `APPLE_CERTIFICATE_P12` | macOS | Base64-encoded Developer ID Application `.p12` certificate (`base64 -i cert.p12 \| pbcopy`) |
+| `APPLE_CERTIFICATE_PASSWORD` | macOS | Password the `.p12` was exported with |
+| `APPLE_ID` | macOS | Apple ID used for notarization |
+| `APPLE_ID_PASSWORD` | macOS | App-specific password for that Apple ID (not the account password) |
+| `APPLE_TEAM_ID` | macOS | Apple Developer Team ID |
+| `CSC_LINK` | Windows | Base64-encoded Authenticode `.pfx` certificate |
+| `CSC_KEY_PASSWORD` | Windows | Password the `.pfx` was exported with |
+
+Requires an active Apple Developer Program membership (for the macOS cert) and a Windows code-signing certificate (standard or EV) — both are paid, and provisioning them is a release-owner task, not something resolvable in code.

--- a/packages/desktop/forge.config.js
+++ b/packages/desktop/forge.config.js
@@ -1,13 +1,55 @@
+// Code signing / notarization is opt-in based on environment variables so that
+// local `npm run make` and CI builds without the relevant repo secrets still
+// produce unsigned installers exactly as before (see issue #295). Once real
+// certificates are provisioned and added as repo secrets, these activate
+// automatically — no further code changes needed. See packages/desktop/README.md
+// for the exact secret names to add.
+
+const macSigningConfigured = Boolean(
+  process.env.APPLE_ID &&
+    process.env.APPLE_ID_PASSWORD &&
+    process.env.APPLE_TEAM_ID &&
+    process.env.APPLE_CERTIFICATE_P12,
+);
+
+const winSigningConfigured = Boolean(
+  process.env.WINDOWS_CERTIFICATE_FILE && process.env.CSC_KEY_PASSWORD,
+);
+
 module.exports = {
   packagerConfig: {
     asar: true,
     name: "Anote AI",
     icon: "./assets/icon",
     extraResource: ["./backend-dist"],
+    // @electron/osx-sign picks up the identity imported into the keychain
+    // by the CI step in .github/workflows/release.yml; no explicit identity
+    // needed here as long as exactly one valid Developer ID cert is present.
+    ...(macSigningConfigured
+      ? {
+          osxSign: {},
+          osxNotarize: {
+            appleId: process.env.APPLE_ID,
+            appleIdPassword: process.env.APPLE_ID_PASSWORD,
+            teamId: process.env.APPLE_TEAM_ID,
+          },
+        }
+      : {}),
   },
   rebuildConfig: {},
   makers: [
-    { name: "@electron-forge/maker-squirrel", config: { name: "anote_ai" } },
+    {
+      name: "@electron-forge/maker-squirrel",
+      config: {
+        name: "anote_ai",
+        ...(winSigningConfigured
+          ? {
+              certificateFile: process.env.WINDOWS_CERTIFICATE_FILE,
+              certificatePassword: process.env.CSC_KEY_PASSWORD,
+            }
+          : {}),
+      },
+    },
     { name: "@electron-forge/maker-dmg", config: { format: "ULFO" } },
     { name: "@electron-forge/maker-deb", config: {} },
   ],


### PR DESCRIPTION
…op releases

Closes the code path from #295. Certs still need to be provisioned and added as repo secrets (paid Apple Developer Program membership + a Windows code-signing cert — a release-owner task, not a code one), but once they exist as secrets, signing activates automatically:

- forge.config.js: osxSign/osxNotarize and maker-squirrel certificateFile only get set when the relevant env vars are present; verified the config is byte-identical to today's when they're absent, so unsigned local/CI builds are unaffected.
- release.yml: adds a macOS keychain-import step and a Windows cert-decode step, both gated on the secret existing, plus passes the signing env vars through to `electron-forge publish`.
- desktop/README.md: documents the exact 7 secret names to add.