### PR TITLE
ci: wire opt-in macOS notarization and Windows code signing for desktop (#295)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,42 @@ jobs:
         run: npm install && npm run build
       - working-directory: packages/desktop
         run: npm install
+
+      # --- Code signing (see issue #295 and packages/desktop/README.md) ---
+      # Both steps are no-ops until the relevant repo secrets are added, so
+      # today's unsigned build/publish is unaffected.
+      - name: Import Apple signing certificate
+        if: matrix.os == 'macos-latest' && secrets.APPLE_CERTIFICATE_P12 != ''
+        env:
+          APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 24)
+          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          echo "$APPLE_CERTIFICATE_P12" | base64 --decode > "$RUNNER_TEMP/apple-cert.p12"
+          security import "$RUNNER_TEMP/apple-cert.p12" -k build.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+          rm "$RUNNER_TEMP/apple-cert.p12"
+
+      - name: Decode Windows signing certificate
+        if: matrix.os == 'windows-latest' && secrets.CSC_LINK != ''
+        shell: pwsh
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+        run: |
+          $bytes = [Convert]::FromBase64String($env:CSC_LINK)
+          $certPath = Join-Path $env:RUNNER_TEMP "windows-cert.pfx"
+          [IO.File]::WriteAllBytes($certPath, $bytes)
+          echo "WINDOWS_CERTIFICATE_FILE=$certPath" >> $env:GITHUB_ENV
+
       - working-directory: packages/desktop
         run: npx electron-forge publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -27,3 +27,19 @@ npm run make
 ```
 
 Outputs in `out/` directory.
+
+## Code signing (releases)
+
+Release builds (`.github/workflows/release.yml`) are unsigned today, which means macOS Gatekeeper and Windows SmartScreen show security warnings on install — see [#295](https://github.com/anote-ai/Panacea/issues/295). Signing is already wired into `forge.config.js` and the release workflow; it activates automatically once these repo secrets exist (**Settings → Secrets and variables → Actions**), no code changes needed:
+
+| Secret | Platform | Description |
+|---|---|---|
+| `APPLE_CERTIFICATE_P12` | macOS | Base64-encoded Developer ID Application `.p12` certificate (`base64 -i cert.p12 \| pbcopy`) |
+| `APPLE_CERTIFICATE_PASSWORD` | macOS | Password the `.p12` was exported with |
+| `APPLE_ID` | macOS | Apple ID used for notarization |
+| `APPLE_ID_PASSWORD` | macOS | App-specific password for that Apple ID (not the account password) |
+| `APPLE_TEAM_ID` | macOS | Apple Developer Team ID |
+| `CSC_LINK` | Windows | Base64-encoded Authenticode `.pfx` certificate |
+| `CSC_KEY_PASSWORD` | Windows | Password the `.pfx` was exported with |
+
+Requires an active Apple Developer Program membership (for the macOS cert) and a Windows code-signing certificate (standard or EV) — both are paid, and provisioning them is a release-owner task, not something resolvable in code.

--- a/packages/desktop/forge.config.js
+++ b/packages/desktop/forge.config.js
@@ -1,13 +1,55 @@
+// Code signing / notarization is opt-in based on environment variables so that
+// local `npm run make` and CI builds without the relevant repo secrets still
+// produce unsigned installers exactly as before (see issue #295). Once real
+// certificates are provisioned and added as repo secrets, these activate
+// automatically — no further code changes needed. See packages/desktop/README.md
+// for the exact secret names to add.
+
+const macSigningConfigured = Boolean(
+  process.env.APPLE_ID &&
+    process.env.APPLE_ID_PASSWORD &&
+    process.env.APPLE_TEAM_ID &&
+    process.env.APPLE_CERTIFICATE_P12,
+);
+
+const winSigningConfigured = Boolean(
+  process.env.WINDOWS_CERTIFICATE_FILE && process.env.CSC_KEY_PASSWORD,
+);
+
 module.exports = {
   packagerConfig: {
     asar: true,
     name: "Anote AI",
     icon: "./assets/icon",
     extraResource: ["./backend-dist"],
+    // @electron/osx-sign picks up the identity imported into the keychain
+    // by the CI step in .github/workflows/release.yml; no explicit identity
+    // needed here as long as exactly one valid Developer ID cert is present.
+    ...(macSigningConfigured
+      ? {
+          osxSign: {},
+          osxNotarize: {
+            appleId: process.env.APPLE_ID,
+            appleIdPassword: process.env.APPLE_ID_PASSWORD,
+            teamId: process.env.APPLE_TEAM_ID,
+          },
+        }
+      : {}),
   },
   rebuildConfig: {},
   makers: [
-    { name: "@electron-forge/maker-squirrel", config: { name: "anote_ai" } },
+    {
+      name: "@electron-forge/maker-squirrel",
+      config: {
+        name: "anote_ai",
+        ...(winSigningConfigured
+          ? {
+              certificateFile: process.env.WINDOWS_CERTIFICATE_FILE,
+              certificatePassword: process.env.CSC_KEY_PASSWORD,
+            }
+          : {}),
+      },
+    },
     { name: "@electron-forge/maker-dmg", config: { format: "ULFO" } },
     { name: "@electron-forge/maker-deb", config: {} },
   ],


### PR DESCRIPTION
Addresses #295.

## What this does — and doesn't — fix

The issue itself says this "requires the release owner to actually obtain and provision paid certificates... not something that can be resolved in code alone." That's still true — I can't buy an Apple Developer Program membership or a Windows code-signing cert. What I *can* do in code is make sure the moment those certs exist as repo secrets, signing turns on with zero further changes. That's what this PR does.

## Changes

- **`packages/desktop/forge.config.js`**: `osxSign`/`osxNotarize` (macOS) and `maker-squirrel`'s `certificateFile`/`certificatePassword` (Windows) are now set conditionally, based on whether the relevant env vars are present. Verified with `node -e "require('./forge.config.js')"` that the resulting config is **byte-identical to today's** when the vars are absent — local `npm run make` and CI builds without secrets are unaffected.
- **`.github/workflows/release.yml`**: adds two new steps to `publish-desktop`, each gated on `if: secrets.X != ''` so they no-op today:
  - macOS: imports `APPLE_CERTIFICATE_P12` into a temporary keychain (standard `security create-keychain`/`security import` pattern, no new third-party Action dependency)
  - Windows: decodes `CSC_LINK` (base64 `.pfx`) to a temp file and exports its path as `WINDOWS_CERTIFICATE_FILE`
  - The `electron-forge publish` step now passes through `APPLE_ID`, `APPLE_ID_PASSWORD`, `APPLE_TEAM_ID`, `APPLE_CERTIFICATE_P12`, `CSC_KEY_PASSWORD`
- **`packages/desktop/README.md`**: new "Code signing (releases)" section listing the exact 7 secret names to add under Settings → Secrets and variables → Actions.
- No new dependencies needed — `@electron/osx-sign` and `@electron/notarize` are already transitive deps of `@electron-forge/core` 7.3.0 via `@electron/packager`.

## Test plan

- [x] `node -e "require('./forge.config.js')"` — confirmed unsigned output is unchanged with no env vars set
- [x] Confirmed signing config activates correctly with all env vars set (manual check, output included in PR discussion if useful)
- [x] `.github/workflows/release.yml` parses as valid YAML
- [x] Can't be tested end-to-end without real certificates — will only be exercised the next time a release tag is pushed after secrets are added

🤖 Generated with [Claude Code](https://claude.com/claude-code)