### PR TITLE
docs: fix stale Autonomous-Intelligence repo references (#294)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@
 ## Repository Structure
 
 ```
-Autonomous-Intelligence/
+Panacea/
 ├── packages/
 │   ├── backend/        # Python Flask API (shared by all frontends)
 │   ├── cli/            # TypeScript CLI tool (anote command)

--- a/CODEBASE_SETUP.md
+++ b/CODEBASE_SETUP.md
@@ -22,8 +22,8 @@ Autonomous Intelligence, also known as **Panacea**, is a multi-agent orchestrati
 
 ```bash
 # 1. Clone the repo
-git clone https://github.com/anote-ai/Autonomous-Intelligence.git
-cd Autonomous-Intelligence
+git clone https://github.com/anote-ai/Panacea.git
+cd Panacea
 
 # 2. Create your local env file and fill in values
 cp .env.example .env

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Within the [Agent Registry](https://anote.ai/community/agents), we have added ma
 5. **Automation**: Emails are automatically sent to the generated list of leads. The system tracks progress, showing the number of emails sent and responses received daily.
 6. **Feedback Loop**: User feedback is incorporated to improve the lead generation process, refine email drafts, or adjust selection criteria for future tasks.
 
-![alt text](https://github.com/nv78/Autonomous-Intelligence/blob/main/materials/assets/ExampleNew.png?raw=true)
+![alt text](materials/assets/ExampleNew.png)
 
 For a full example of this working end to end for this use case, please see [Anote's Upreach Product](https://anote.ai/upreach).
 
@@ -54,6 +54,6 @@ That starts the frontend, backend, MySQL, Redis, and Tika together.
 
 If Docker is installed but not running, start Docker Desktop first or `docker compose up` will fail before the app boots.
 
-For native local development and testing instructions, see [`CODEBASE_SETUP.md`](/Users/natanvidra/Workspace/Autonomous-Intelligence/CODEBASE_SETUP.md).
+For native local development and testing instructions, see [`CODEBASE_SETUP.md`](CODEBASE_SETUP.md).
 
 For any questions or issues, please [join our slack community](https://join.slack.com/t/anote-ai/shared_invite/zt-2vdh1p5xt-KWvtBZEprhrCzU6wrRPwNA) or [contact us](mailto:nvidra@anote.ai).

--- a/packages/docs/docs/development/architecture.md
+++ b/packages/docs/docs/development/architecture.md
@@ -3,7 +3,7 @@
 ## Monorepo Structure
 
 ```
-Autonomous-Intelligence/
+Panacea/
 ├── packages/
 │   ├── backend/    # Python Flask — unified API + agent streaming + RAG
 │   ├── cli/        # TypeScript — anote terminal CLI

--- a/packages/docs/docs/development/contributing.md
+++ b/packages/docs/docs/development/contributing.md
@@ -3,8 +3,8 @@
 ## Setup
 
 ```bash
-git clone https://github.com/anote-ai/Autonomous-Intelligence
-cd Autonomous-Intelligence
+git clone https://github.com/anote-ai/Panacea
+cd Panacea
 
 # Install Node.js packages
 npm install

--- a/packages/docs/docs/getting-started/installation.md
+++ b/packages/docs/docs/getting-started/installation.md
@@ -19,8 +19,8 @@ code --install-extension anote-ai.anote-ai-coding
 ## Web App (Self-hosted)
 
 ```bash
-git clone https://github.com/anote-ai/Autonomous-Intelligence
-cd Autonomous-Intelligence
+git clone https://github.com/anote-ai/Panacea
+cd Panacea
 cp packages/backend/.env.example packages/backend/.env
 # Edit .env with your API keys
 docker compose up
@@ -30,7 +30,7 @@ Frontend: http://localhost:3000 · Backend: http://localhost:5000
 
 ## Desktop App
 
-Download the latest release from [GitHub Releases](https://github.com/anote-ai/Autonomous-Intelligence/releases).
+Download the latest release from [GitHub Releases](https://github.com/anote-ai/Panacea/releases).
 
 Available for: **macOS** (DMG), **Windows** (installer), **Linux** (AppImage/DEB/RPM).
 

--- a/packages/docs/mkdocs.yml
+++ b/packages/docs/mkdocs.yml
@@ -3,8 +3,8 @@ site_url: https://docs.anote.ai
 site_description: Unified AI coding assistant and chatbot platform
 site_author: Anote AI
 
-repo_name: anote-ai/autonomous-intelligence
-repo_url: https://github.com/anote-ai/Autonomous-Intelligence
+repo_name: anote-ai/Panacea
+repo_url: https://github.com/anote-ai/Panacea
 
 theme:
   name: material

--- a/packages/sdk-py/pyproject.toml
+++ b/packages/sdk-py/pyproject.toml
@@ -23,8 +23,8 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/anote-ai/Autonomous-Intelligence"
-Repository = "https://github.com/anote-ai/Autonomous-Intelligence"
+Homepage = "https://github.com/anote-ai/Panacea"
+Repository = "https://github.com/anote-ai/Panacea"
 
 [tool.hatch.build.targets.wheel]
 packages = ["anote_sdk"]

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,4 +1,4 @@
-# Terraform — AWS deployment for Autonomous-Intelligence
+# Terraform — AWS deployment for Panacea
 
 Provisions: ECR repo, ECS Fargate cluster/service for the backend behind an ALB,
 RDS MySQL, and an S3 + CloudFront distribution for the web frontend.


### PR DESCRIPTION
Closes #294.

## Changes

Repo-wide replace of `anote-ai/Autonomous-Intelligence` → `anote-ai/Panacea` (and bare clone-directory references → `Panacea`), reviewed file by file per the issue's suggested approach:

- `packages/docs/mkdocs.yml` — `repo_name`/`repo_url`
- `packages/docs/docs/development/architecture.md` + `CLAUDE.md` — monorepo diagram root folder name
- `packages/docs/docs/development/contributing.md`, `packages/docs/docs/getting-started/installation.md`, `CODEBASE_SETUP.md` — clone instructions
- `installation.md` — "latest release" link (was pointing at a repo with no releases under the new name)
- `terraform/README.md` — title
- `README.md` — two broken links found while in there:
  - the example image pointed at a personal fork (`nv78/Autonomous-Intelligence`); switched to a relative repo path (`materials/assets/ExampleNew.png`) so it doesn't depend on org/repo/branch naming going forward
  - the `CODEBASE_SETUP.md` link was a hardcoded absolute path on someone's local machine (`/Users/natanvidra/Workspace/...`), broken for literally everyone else
- `packages/sdk-py/pyproject.toml` `Homepage`/`Repository` — found while auditing, not in the issue's original file list but the same bug

## Deliberately left unchanged

`CLAUDE.md`'s "Source Repositories (preserved, not deleted)" table entry for `anote-ai/Autonomous-Intelligence` (original). That's the real, historically-accurate name of the actual predecessor repo that got merged into `packages/backend` + `packages/web` — before *this* monorepo was itself later renamed to Panacea. Renaming that entry to Panacea would misrepresent history rather than fix a broken link, so I left it as-is.

`packages/desktop/forge.config.js` — already fixed in a prior PR per the issue.

## Test plan

- [x] `grep -rn "Autonomous-Intelligence"` repo-wide — only the intentional CLAUDE.md history entry remains
- [x] `mkdocs build --strict` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)