### PR TITLE
ci: run tests before publishing CLI and VS Code extension (#293)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
         run: npm install
       - working-directory: packages/cli
         run: npm run build
+      - name: Run tests
+        working-directory: packages/cli
+        run: npm test --if-present
       - working-directory: packages/cli
         run: npm publish --access public
         env:
@@ -39,6 +42,9 @@ jobs:
           node-version: 20.19.0
       - working-directory: packages/vscode
         run: npm install
+      - name: Run tests
+        working-directory: packages/vscode
+        run: npm test --if-present
       - run: npm install -g @vscode/vsce
       - working-directory: packages/vscode
         run: vsce publish -p ${{ secrets.VSCE_PAT }}


### PR DESCRIPTION
Closes #293.

## What happened

The original `AI-Assisted-Coding-Tool` release workflow ran tests before publishing. That step got dropped when it was ported into this repo's monorepo-aware `.github/workflows/release.yml` — `publish-cli` and `publish-vscode` both went straight from `npm install`/build to `npm publish`/`vsce publish`.

`ci.yml` gates merges to `main` with `npm test --if-present` for the CLI, so in practice a release tag pushed from a green `main` is already tested — but the release workflow itself had no independent guarantee. A tag pushed from a branch that skipped CI, or a hotfix pushed directly, would publish untested code straight to npm and the Marketplace.

## Change

Adds an `npm test --if-present` step to both jobs, before the publish step, matching the original repo's behavior and `ci.yml`'s existing convention for the CLI package.

- **`publish-cli`**: real gate — the CLI has an actual vitest suite (`packages/cli/package.json`).
- **`publish-vscode`**: currently a no-op — there's no `test` script in `packages/vscode/package.json` yet, so `--if-present` skips it silently (same as `ci.yml` does today). It'll activate automatically the moment one's added, no further workflow changes needed.

Per the issue's scope note, this is a deliberate behavior change (release now depends on tests passing) rather than something to just quietly add — flagging that explicitly for review.

## Test plan

- [x] `npm install && npm test --if-present` in `packages/cli` — 9/9 tests pass locally, so this doesn't immediately break the next release
- [x] `.github/workflows/release.yml` parses as valid YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)