### PR TITLE
Fix backend docker-compose.yml host port conflicts (tika, Ray)

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -7,7 +7,12 @@ services:
     restart: unless-stopped
     ports:
       - "5000:5000"  # Map container's 5000 to host's 8000
-      - "6379:6379"  # Ray
+      # NOTE: host port 6379 intentionally not published here -- this machine
+      # already has an unrelated redis container bound to host:6379 (a
+      # separate anote-product stack). Ray's GCS port only needs to be
+      # reachable from other containers on this stack's internal network
+      # (Flask talks to Ray in-process), not from the host, so dropping the
+      # host publish avoids the conflict without touching Ray's behavior.
     volumes:
       - ./:/app
       - ./db:/app/db
@@ -71,7 +76,7 @@ services:
     environment:
       - TIKA_SERVER_ENDPOINT=http://tika:9998
     ports:
-      - "9998:9998"
+      - "19998:9998"  # remapped: host:9998 already taken by an unrelated stack
     volumes:
       - tika-data:/data
     networks:


### PR DESCRIPTION
## Summary

`backend/docker-compose.yml` hard-codes host ports `9998` (tika) and `6379` (Ray) that collide with any other locally-running Docker stack already bound to those ports (hit this directly while verifying the Cookbook recipes against a fresh local `backend/` stack, with an unrelated `anote-product` stack already running).

Neither port needs to be published to the host:
- `tika:9998` is reached by the backend container over Docker's internal network regardless of whether the host port is published.
- Ray's GCS port (`6379`) is only used in-process by the Flask app talking to its own Ray cluster; nothing outside the container needs to reach it.

So this drops the Ray host publish entirely and remaps tika's host side to `19998`, without touching container-to-container behavior.

## Test plan

- [x] `docker compose up --build` from `backend/` starts cleanly with this change alongside another unrelated stack already bound to host `6379`/`9998`
- [x] `curl http://localhost:5000/health` -> `Healthy`
- [x] Backend successfully talks to tika (verified via document ingestion in a downstream testing pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)