### PR TITLE
Fix rebrand regressions from #343 (wrong repo, dead link, font)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10120,7 +10120,7 @@
     },
     "packages/cli": {
       "name": "@anote-ai/anote",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.89",
@@ -10161,7 +10161,7 @@
     },
     "packages/vscode": {
       "name": "anote-ai-coding",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.89",
         "@anthropic-ai/sdk": "^0.74.0"
@@ -11713,7 +11713,7 @@
         "read": "^1.0.7",
         "secretlint": "^10.1.2",
         "semver": "^7.5.2",
-        "tmp": "^0.2.3",
+        "tmp": "^0.2.7",
         "typed-rest-client": "^1.8.4",
         "url-join": "^4.0.1",
         "xml2js": "^0.5.0",
@@ -16426,7 +16426,7 @@
         "chokidar": "^4.0.3",
         "consola": "^3.4.0",
         "debug": "^4.4.0",
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.28.1",
         "fix-dts-default-cjs-exports": "^1.0.0",
         "joycon": "^3.1.1",
         "picocolors": "^1.1.1",
@@ -16721,7 +16721,7 @@
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
         "tinyrainbow": "^3.1.0",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "vite": "^8.0.16",
         "why-is-node-running": "^2.3.0"
       },
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10120,7 +10120,7 @@
     },
     "packages/cli": {
       "name": "@anote-ai/anote",
-      "version": "1.0.6",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.89",
@@ -10161,7 +10161,7 @@
     },
     "packages/vscode": {
       "name": "anote-ai-coding",
-      "version": "1.1.1",
+      "version": "1.1.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.89",
         "@anthropic-ai/sdk": "^0.74.0"
@@ -11713,7 +11713,7 @@
         "read": "^1.0.7",
         "secretlint": "^10.1.2",
         "semver": "^7.5.2",
-        "tmp": "^0.2.7",
+        "tmp": "^0.2.3",
         "typed-rest-client": "^1.8.4",
         "url-join": "^4.0.1",
         "xml2js": "^0.5.0",
@@ -16426,7 +16426,7 @@
         "chokidar": "^4.0.3",
         "consola": "^3.4.0",
         "debug": "^4.4.0",
-        "esbuild": "^0.28.1",
+        "esbuild": "^0.27.0",
         "fix-dts-default-cjs-exports": "^1.0.0",
         "joycon": "^3.1.1",
         "picocolors": "^1.1.1",
@@ -16721,7 +16721,7 @@
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
         "tinyrainbow": "^3.1.0",
-        "vite": "^8.0.16",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "dependencies": {

--- a/packages/docs/docs/getting-started/installation.md
+++ b/packages/docs/docs/getting-started/installation.md
@@ -23,9 +23,9 @@ code --install-extension Anote.anote-ai-coding
 ## Web App (Self-hosted)
 
 ```bash
-git clone https://github.com/anote-ai/Autonomous-Intelligence
-cd Autonomous-Intelligence
-cp backend/.env.example backend/.env
+git clone https://github.com/anote-ai/Panacea
+cd Panacea
+cp packages/backend/.env.example packages/backend/.env
 # Edit .env with your API keys
 docker compose up --build
 ```
@@ -34,7 +34,7 @@ Frontend: http://localhost:3000 · Backend: http://localhost:5000
 
 ## Desktop App
 
-Download the latest release from [GitHub Releases](https://github.com/anote-ai/Autonomous-Intelligence/releases).
+Download the latest release from [GitHub Releases](https://github.com/anote-ai/Panacea/releases).
 
 Available for: **macOS** (DMG), **Windows** (installer), **Linux** (AppImage/DEB/RPM).
 

--- a/packages/docs/mkdocs.yml
+++ b/packages/docs/mkdocs.yml
@@ -3,8 +3,8 @@ site_url: https://docs.ourogen.ai
 site_description: Unified AI coding assistant and chatbot platform
 site_author: Ourogen
 
-repo_name: anote-ai/Autonomous-Intelligence
-repo_url: https://github.com/anote-ai/Autonomous-Intelligence
+repo_name: anote-ai/Panacea
+repo_url: https://github.com/anote-ai/Panacea
 
 extra:
   homepage: https://ourogen.ai

--- a/packages/docs/overrides/partials/header.html
+++ b/packages/docs/overrides/partials/header.html
@@ -15,7 +15,7 @@
 {% endif %}
 <header class="{{ class }} anote-header" data-md-component="header">
   <nav class="md-header__inner md-grid" aria-label="{{ lang.t('header') }}">
-    <a href="{{ nav.homepage.url | url }}" title="{{ config.site_name | e }}" class="md-header__button md-logo anote-header__logo" aria-label="{{ config.site_name }}" data-md-component="logo">
+    <a href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}" title="{{ config.site_name | e }}" class="md-header__button md-logo anote-header__logo" aria-label="{{ config.site_name }}" data-md-component="logo">
       {% include "partials/logo.html" %}
       <span class="anote-header__site-name">{{ config.site_name }}</span>
     </a>

--- a/packages/vscode/src/chatViewProvider.ts
+++ b/packages/vscode/src/chatViewProvider.ts
@@ -349,6 +349,7 @@ export class AnnoteChatViewProvider implements vscode.WebviewViewProvider {
       letter-spacing: 0;
     }
     #model-badge {
+      font: inherit;
       font-size: 11px;
       padding: 3px 7px;
       border-radius: 999px;


### PR DESCRIPTION
## Summary

Follow-up to #343 ("Unify Ourogen branding and improve product accessibility"), which was reviewed post-merge. Most of that PR is safe cosmetic renaming, but it introduced four concrete bugs:

- `packages/docs/mkdocs.yml`: `repo_name`/`repo_url` were changed from `anote-ai/Panacea` to `anote-ai/Autonomous-Intelligence` — breaks "Edit this page" and the footer repo link sitewide, since the docs actually live in and are built from this repo
- `packages/docs/docs/getting-started/installation.md`: the self-hosted install steps and desktop releases link pointed at the same wrong repo, and were missing the `packages/` prefix on `.env.example`
- `packages/docs/overrides/partials/header.html`: the logo link was changed to ignore the still-configured `extra.homepage` (`https://ourogen.ai`), so clicking the logo landed on the docs' own index instead of the marketing site
- `packages/vscode/src/chatViewProvider.ts`: the model-name badge changed from `<span>` to `<button>` (an a11y improvement) without a font reset, so it silently switched to the browser's default button font

Also reverts an unrelated `package-lock.json` version-drift change that installing `packages/vscode`'s dependencies picked up.

## Test plan
- [x] `mkdocs build --strict` passes
- [x] VS Code extension `tsc` build passes
- [x] Verified the current `create_document()` insert path already sets `user_id` correctly (see comment on #325 — that issue is stale, not fixed here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJnyx5NghSNs3rM6va4YYa

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJnyx5NghSNs3rM6va4YYa)_