### PR TITLE
Fix stale Autonomous-Intelligence repo references after rename to Panacea

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@
 ## Repository Structure
 
 ```
-Autonomous-Intelligence/
+Panacea/
 ├── packages/
 │   ├── backend/        # Python Flask API (shared by all frontends)
 │   ├── cli/            # TypeScript CLI tool (anote command)
@@ -145,5 +145,5 @@ Copy `packages/backend/.env.example` → `packages/backend/.env`:
 
 This monorepo consolidates:
 - `anote-ai/AI-Assisted-Coding-Tool` → `packages/cli/`, `packages/sdk/`, `packages/vscode/`
-- `anote-ai/Autonomous-Intelligence` (original) → `packages/backend/`, `packages/web/`
+- `anote-ai/Panacea` (original) → `packages/backend/`, `packages/web/`
 - `anote-ai/PrivateGPT` → `packages/desktop/`

--- a/CODEBASE_SETUP.md
+++ b/CODEBASE_SETUP.md
@@ -22,8 +22,8 @@ Autonomous Intelligence, also known as **Panacea**, is a multi-agent orchestrati
 
 ```bash
 # 1. Clone the repo
-git clone https://github.com/anote-ai/Autonomous-Intelligence.git
-cd Autonomous-Intelligence
+git clone https://github.com/anote-ai/Panacea.git
+cd Panacea
 
 # 2. Create your local env file and fill in values
 cp .env.example .env

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Within the [Agent Registry](https://anote.ai/community/agents), we have added ma
 5. **Automation**: Emails are automatically sent to the generated list of leads. The system tracks progress, showing the number of emails sent and responses received daily.
 6. **Feedback Loop**: User feedback is incorporated to improve the lead generation process, refine email drafts, or adjust selection criteria for future tasks.
 
-![alt text](https://github.com/nv78/Autonomous-Intelligence/blob/main/materials/assets/ExampleNew.png?raw=true)
+![alt text](https://github.com/nv78/Panacea/blob/main/materials/assets/ExampleNew.png?raw=true)
 
 For a full example of this working end to end for this use case, please see [Anote's Upreach Product](https://anote.ai/upreach).
 

--- a/packages/sdk-py/pyproject.toml
+++ b/packages/sdk-py/pyproject.toml
@@ -23,8 +23,8 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/anote-ai/Autonomous-Intelligence"
-Repository = "https://github.com/anote-ai/Autonomous-Intelligence"
+Homepage = "https://github.com/anote-ai/Panacea"
+Repository = "https://github.com/anote-ai/Panacea"
 
 [tool.hatch.build.targets.wheel]
 packages = ["anote_sdk"]

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,4 +1,4 @@
-# Terraform — AWS deployment for Autonomous-Intelligence
+# Terraform — AWS deployment for Panacea
 
 Provisions: ECR repo, ECS Fargate cluster/service for the backend behind an ALB,
 RDS MySQL, and an S3 + CloudFront distribution for the web frontend.


### PR DESCRIPTION
## Summary
- Updated repository URLs in `packages/sdk-py/pyproject.toml` to point to Panacea
- Fixed clone instructions in `CODEBASE_SETUP.md` to use correct repo name
- Updated image reference in `README.md` to use Panacea repository
- Updated repository structure diagram in `CLAUDE.md` 
- Updated Terraform README title to reflect new project name

Resolves #294

#### Test plan
- Verified all occurrences of "Autonomous-Intelligence" have been replaced with "Panacea"
- Confirmed no remaining stale references via grep search
- All 5 files updated consistently

@nv78 - ready for review